### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+    - openjdk6
+    - openjdk7
+    - oraclejdk7
+notifications:
+    email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Esri/geometry-api-java.png?branch=master)](https://travis-ci.org/Esri/geometry-api-java)
+
 # geometry-api-java
 
 The Esri Geometry API for Java can be used to enable spatial data processing in 3rd-party data-processing solutions.  Developers of custom MapReduce-based applications for Hadoop can use this API for spatial processing of data in the Hadoop system.  The API is also used by the [Hive UDF’s](https://github.com/Esri/spatial-framework-for-hadoop) and could be used by developers building geometry functions for 3rd-party applications such as [Cassandra]( https://cassandra.apache.org/), [HBase](http://hbase.apache.org/), [Storm](http://storm-project.net/) and many other Java-based “big data” applications.


### PR DESCRIPTION
This pull request adds support for using Travis CI. It runs the test suite on OpenJDK 6, OpenJDK 7, and Oracle JDK 7 (these are the only supported JDK versions on Travis CI). This pull request also adds a build status badge to the README that is displayed when this repo is viewed on GitHub. It currently says Unknown, as the badge points to the Esri project so no changes will be needed (code wise) if this PR is merged. Someone from Esri with a commit bit on the repo will need to log into Travis CI (with their GitHub account) and turn on tracking for the repo.
