### PR TITLE
GeometryCursor: make tock method public

### DIFF
--- a/src/com/esri/core/geometry/GeometryCursor.java
+++ b/src/com/esri/core/geometry/GeometryCursor.java
@@ -47,5 +47,5 @@ public abstract class GeometryCursor {
 	 *This method is to be used together with the tick() method on the ListeningGeometryCursor.
 	 *Call tock() for each tick() on the ListeningGeometryCursor.
 	 */
-	protected boolean tock() { return true; }
+	public boolean tock() { return true; }
 }


### PR DESCRIPTION
Declaring GeometryCursor.tock as public rather than protected allows use of ListeningGeometryCursor for better performance in ST_Aggr_Union in spatial-framework-for-hadoop.
