### PR TITLE
Disable doclint in maven-javadoc-plugin execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 			</roles>
 		</developer>
 	</developers>
-	
+
 	<scm>
 		<connection>scm:git:git@github.com:Esri/geometry-api-java.git</connection>
 		<developerConnection>scm:git:git@github.com:Esri/geometry-api-java.git</developerConnection>
@@ -74,14 +74,14 @@
 			</build>
 		</profile>
 	</profiles>
-	
+
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
-	
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -172,6 +172,9 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Maven configuration to disable doclint in maven-javadoc-plugin execution.  [Turning off doclint in JDK 8 Javadoc ](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html) explains why this is necessary.