### PR TITLE
Android source compatibility

### DIFF
--- a/src/main/java/com/esri/core/geometry/JSONObjectEnumerator.java
+++ b/src/main/java/com/esri/core/geometry/JSONObjectEnumerator.java
@@ -23,11 +23,9 @@
  */
 package com.esri.core.geometry;
 
-import java.util.ArrayList;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
-import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.Iterator;
 
 final class JSONObjectEnumerator {
 
@@ -69,12 +67,29 @@ final class JSONObjectEnumerator {
 	boolean next() {
 		if (!m_bStarted) {
 			m_currentIndex = 0;
-			m_keys = JSONObject.getNames(m_jsonObject);
+			m_keys = getNames(m_jsonObject);
 			m_bStarted = true;
 		} else if (m_currentIndex != m_jsonObject.length()) {
 			m_currentIndex++;
 		}
 
 		return m_currentIndex != m_jsonObject.length();
+	}
+
+	// copied from https://github.com/Esri/JSON-java/blob/master/JSONObject.java
+	private static String[] getNames(JSONObject jo) {
+		int length = jo.length();
+		if (length == 0) {
+			return null;
+		}
+		//noinspection unchecked - sic
+		Iterator<String> iterator = jo.keys();
+		String[] names = new String[length];
+		int i = 0;
+		while (iterator.hasNext()) {
+			names[i] = iterator.next();
+			i += 1;
+		}
+		return names;
 	}
 }


### PR DESCRIPTION
**Problem**
Google included their own slightly incompatible version of `org.json:json` in Android, and the Android Gradle plugin automatically excludes dependencies on any other version.  Google's implementation of `JSONObject` is missing the static method `getNames(JSONObject)`.  ProGuard minimization detects the missing method and the build fails:

> Warning: com.esri.core.geometry.JSONObjectEnumerator: can't find referenced method 'java.lang.String[] getNames(org.json.JSONObject)' in library class org.json.JSONObject

**Solution**
I copied the implementation of `getNames(JSONObject)` into `JSONObjectEnumerator` and made it private to avoid polluting the API.