### PR TITLE
Update Maven coordinates to the latest stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project is also available as a [Maven](http://maven.apache.org/) dependency:
 <dependency>
   <groupId>com.esri.geometry</groupId>
   <artifactId>esri-geometry-api</artifactId>
-  <version>1.2.1</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Change example Maven coordinates from the old version 1.2.1 to the newest stable version: 2.0.0