### PR TITLE
Add OGCGeometry::estimateMemorySize API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
 		<!-- dependency versions -->
 		<jackson.version>2.6.5</jackson.version>
 		<junit.version>4.12</junit.version>
+		<jol.version>0.2</jol.version>
 
 		<!-- plugin versions -->
 		<compiler.plugin.version>2.3.1</compiler.plugin.version>
@@ -118,6 +119,14 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.openjdk.jol</groupId>
+			<artifactId>jol-core</artifactId>
+			<version>${jol.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/esri/core/geometry/AttributeStreamBase.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamBase.java
@@ -47,6 +47,13 @@ abstract class AttributeStreamBase {
 	public abstract int virtualSize();
 
 	/**
+	 * Returns an estimate of this object size in bytes.
+	 *
+	 * @return Returns an estimate of this object size in bytes.
+	 */
+	public abstract long estimateMemorySize();
+
+	/**
 	 * Returns the Persistence type of the stream.
 	 */
 	public abstract int getPersistence();

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfDbl.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfDbl.java
@@ -26,8 +26,13 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_DBL;
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT32;
+import static com.esri.core.geometry.SizeOf.sizeOfDoubleArray;
 
 final class AttributeStreamOfDbl extends AttributeStreamBase {
 
@@ -171,6 +176,12 @@ final class AttributeStreamOfDbl extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_DBL + sizeOfDoubleArray(m_buffer.length);
 	}
 
 	// @Override

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfFloat.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfFloat.java
@@ -26,10 +26,13 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
 
-final class AttributeStreamOfFloat extends AttributeStreamBase {
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_FLOAT;
+import static com.esri.core.geometry.SizeOf.sizeOfFloatArray;
 
+final class AttributeStreamOfFloat extends AttributeStreamBase {
 	private float[] m_buffer = null;
 	private int m_size;
 
@@ -143,6 +146,12 @@ final class AttributeStreamOfFloat extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_FLOAT + sizeOfFloatArray(m_buffer.length);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfInt16.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfInt16.java
@@ -26,10 +26,13 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
 
-final class AttributeStreamOfInt16 extends AttributeStreamBase {
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT16;
+import static com.esri.core.geometry.SizeOf.sizeOfShortArray;
 
+final class AttributeStreamOfInt16 extends AttributeStreamBase {
 	private short[] m_buffer = null;
 	private int m_size;
 
@@ -143,6 +146,12 @@ final class AttributeStreamOfInt16 extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_INT16 + sizeOfShortArray(m_buffer.length);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfInt32.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfInt32.java
@@ -26,11 +26,14 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-final class AttributeStreamOfInt32 extends AttributeStreamBase {
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT32;
+import static com.esri.core.geometry.SizeOf.sizeOfIntArray;
 
+final class AttributeStreamOfInt32 extends AttributeStreamBase {
 	private int[] m_buffer = null;
 	private int m_size;
 
@@ -156,6 +159,12 @@ final class AttributeStreamOfInt32 extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_INT32 + sizeOfIntArray(m_buffer.length);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfInt64.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfInt64.java
@@ -26,10 +26,13 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
 
-final class AttributeStreamOfInt64 extends AttributeStreamBase {
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT64;
+import static com.esri.core.geometry.SizeOf.sizeOfLongArray;
 
+final class AttributeStreamOfInt64 extends AttributeStreamBase {
 	private long[] m_buffer = null;
 	private int m_size;
 
@@ -143,6 +146,12 @@ final class AttributeStreamOfInt64 extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_INT64 + sizeOfLongArray(m_buffer.length);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfInt8.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfInt8.java
@@ -26,7 +26,11 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
 import java.nio.ByteBuffer;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT8;
+import static com.esri.core.geometry.SizeOf.sizeOfByteArray;
 
 final class AttributeStreamOfInt8 extends AttributeStreamBase {
 
@@ -150,6 +154,12 @@ final class AttributeStreamOfInt8 extends AttributeStreamBase {
 	@Override
 	public int virtualSize() {
 		return size();
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ATTRIBUTE_STREAM_OF_INT8 + sizeOfByteArray(m_buffer.length);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/Envelope.java
+++ b/src/main/java/com/esri/core/geometry/Envelope.java
@@ -25,9 +25,11 @@
 
 package com.esri.core.geometry;
 
+import com.esri.core.geometry.VertexDescription.Semantics;
+
 import java.io.Serializable;
 
-import com.esri.core.geometry.VertexDescription.Semantics;
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ENVELOPE;
 
 /**
  * An envelope is an axis-aligned rectangle.
@@ -443,6 +445,12 @@ public class Envelope extends Geometry implements Serializable {
 	@Override
 	public int getDimension() {
 		return 2;
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_ENVELOPE + m_envelope.estimateMemorySize() + estimateMemorySize(m_attributes);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/Envelope2D.java
+++ b/src/main/java/com/esri/core/geometry/Envelope2D.java
@@ -28,12 +28,14 @@ import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_ENVELOPE2D;
+
 /**
  * An axis parallel 2-dimensional rectangle.
  */
 public final class Envelope2D implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private final static int XLESSXMIN = 1;
 	// private final int XGREATERXMAX = 2;
 	private final static int YLESSYMIN = 4;
@@ -78,6 +80,11 @@ public final class Envelope2D implements Serializable {
 
 	public Envelope2D(Envelope2D other) {
 		setCoords(other);
+	}
+
+	public int estimateMemorySize()
+	{
+		return SIZE_OF_ENVELOPE2D;
 	}
 	
 	public void setCoords(double _x, double _y) {

--- a/src/main/java/com/esri/core/geometry/Geometry.java
+++ b/src/main/java/com/esri/core/geometry/Geometry.java
@@ -25,10 +25,10 @@
 
 package com.esri.core.geometry;
 
-import com.esri.core.geometry.VertexDescription.Semantics;
-
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+
+import static com.esri.core.geometry.SizeOf.sizeOfDoubleArray;
 
 /**
  * Common properties and methods shared by all geometric objects. Geometries are
@@ -149,6 +149,22 @@ public abstract class Geometry implements Serializable {
 	 * @return Returns the integer value of the dimension of geometry.
 	 */
 	public abstract int getDimension();
+
+	/**
+	 * Returns an estimate of this object size in bytes.
+	 * <p>
+	 * This estimate doesn't include the size of the {@link VertexDescription} object
+	 * because instances of {@link VertexDescription} are shared among
+	 * geometry objects.
+	 * 
+	 * @return Returns an estimate of this object size in bytes.
+	 */
+	public abstract long estimateMemorySize();
+
+	protected static long estimateMemorySize(double[] attributes)
+	{
+		return attributes != null ? sizeOfDoubleArray(attributes.length) : 0;
+	}
 
 	/**
 	 * Returns the VertexDescription of this geomtry.

--- a/src/main/java/com/esri/core/geometry/Line.java
+++ b/src/main/java/com/esri/core/geometry/Line.java
@@ -29,6 +29,8 @@ import com.esri.core.geometry.VertexDescription.Semantics;
 
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_LINE;
+
 /**
  * A straight line between a pair of points.
  * 
@@ -38,6 +40,12 @@ public final class Line extends Segment implements Serializable {
 	@Override
 	public Geometry.Type getType() {
 		return Type.Line;
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_LINE + estimateMemorySize(m_attributes);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/MultiPathImpl.java
+++ b/src/main/java/com/esri/core/geometry/MultiPathImpl.java
@@ -25,10 +25,9 @@
 
 package com.esri.core.geometry;
 
-import com.esri.core.geometry.MultiVertexGeometryImpl.DirtyFlags;
+import static com.esri.core.geometry.SizeOf.SIZE_OF_MULTI_PATH_IMPL;
 
 final class MultiPathImpl extends MultiVertexGeometryImpl {
-
 	protected boolean m_bPolygon;
 	protected Point m_moveToPoint;
 	protected double m_cachedLength2D;
@@ -59,6 +58,27 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	static int[] _segmentParamSizes = { 0, 0, 6, 0, 8, 0 }; // None, Line,
 															// Bezier, XXX, Arc,
 															// XXX;
+
+	@Override
+	public long estimateMemorySize()
+	{
+		long size = SIZE_OF_MULTI_PATH_IMPL +
+			+ (m_envelope != null ? m_envelope.estimateMemorySize() : 0)
+			+ (m_moveToPoint != null ? m_moveToPoint.estimateMemorySize() : 0)
+			+ (m_cachedRingAreas2D != null ? m_cachedRingAreas2D.estimateMemorySize() : 0)
+			+ m_paths.estimateMemorySize()
+			+ m_pathFlags.estimateMemorySize()
+			+ (m_segmentFlags != null ? m_segmentFlags.estimateMemorySize() : 0)
+			+ (m_segmentParamIndex != null ? m_segmentParamIndex.estimateMemorySize() : 0)
+			+ (m_segmentParams != null ? m_segmentParams.estimateMemorySize() : 0);
+
+		if (m_vertexAttributes != null) {
+			for (int i = 0; i < m_vertexAttributes.length; i++) {
+				size += m_vertexAttributes[i].estimateMemorySize();
+			}
+		}
+		return size;
+	}
 
 	public boolean hasNonLinearSegments() {
 		return m_curveParamwritePoint > 0;

--- a/src/main/java/com/esri/core/geometry/MultiPoint.java
+++ b/src/main/java/com/esri/core/geometry/MultiPoint.java
@@ -26,6 +26,8 @@ package com.esri.core.geometry;
 
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_MULTI_POINT;
+
 /**
  * A Multipoint is a collection of points. A multipoint is a one-dimensional
  * geometry object. Multipoints can be used to store a collection of point-based
@@ -256,6 +258,12 @@ public class MultiPoint extends MultiVertexGeometry implements
 	@Override
 	public int getDimension() {
 		return 0;
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_MULTI_POINT + m_impl.estimateMemorySize();
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/MultiPointImpl.java
+++ b/src/main/java/com/esri/core/geometry/MultiPointImpl.java
@@ -26,11 +26,12 @@ package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Semantics;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_MULTI_POINT_IMPL;
+
 /**
  * The MultiPoint is a collection of points.
  */
 final class MultiPointImpl extends MultiVertexGeometryImpl {
-
 	public MultiPointImpl() {
 		super();
 		m_description = VertexDescriptionDesignerImpl.getDefaultDescriptor2D();
@@ -245,6 +246,19 @@ final class MultiPointImpl extends MultiVertexGeometryImpl {
 	@Override
 	public int getDimension() {
 		return 0;
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		long size = SIZE_OF_MULTI_POINT_IMPL + (m_envelope != null ? m_envelope.estimateMemorySize() : 0);
+
+		if (m_vertexAttributes != null) {
+			for (int i = 0; i < m_vertexAttributes.length; i++) {
+				size += m_vertexAttributes[i].estimateMemorySize();
+			}
+		}
+		return size;
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/Point.java
+++ b/src/main/java/com/esri/core/geometry/Point.java
@@ -28,6 +28,8 @@ import com.esri.core.geometry.VertexDescription.Semantics;
 
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_POINT;
+
 /**
  * A Point is a zero-dimensional object that represents a specific (X,Y)
  * location in a two-dimensional XY-Plane. In case of Geographic Coordinate
@@ -37,7 +39,7 @@ public class Point extends Geometry implements Serializable {
 	//We are using writeReplace instead.
 	//private static final long serialVersionUID = 2L;
 
-	double[] m_attributes; // use doubles to store everything (long are bitcast)
+    double[] m_attributes; // use doubles to store everything (long are bitcast)
 
 	/**
 	 * Creates an empty 2D point.
@@ -367,6 +369,12 @@ public class Point extends Geometry implements Serializable {
 	@Override
 	public int getDimension() {
 		return 0;
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_POINT + estimateMemorySize(m_attributes);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/Polygon.java
+++ b/src/main/java/com/esri/core/geometry/Polygon.java
@@ -27,11 +27,12 @@ package com.esri.core.geometry;
 
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_POLYGON;
+
 /**
  * A polygon is a collection of one or many interior or exterior rings.
  */
 public class Polygon extends MultiPath implements Serializable {
-
 	private static final long serialVersionUID = 2L;// TODO:remove as we use
 													// writeReplace and
 													// GeometrySerializer
@@ -60,6 +61,11 @@ public class Polygon extends MultiPath implements Serializable {
 	@Override
 	public Geometry.Type getType() {
 		return Type.Polygon;
+	}
+
+	@Override
+	public long estimateMemorySize() {
+		return SIZE_OF_POLYGON + m_impl.estimateMemorySize();
 	}
 
 	/**

--- a/src/main/java/com/esri/core/geometry/Polyline.java
+++ b/src/main/java/com/esri/core/geometry/Polyline.java
@@ -27,6 +27,8 @@ package com.esri.core.geometry;
 
 import java.io.Serializable;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_POLYLINE;
+
 /**
  * A polyline is a collection of one or many paths.
  * 
@@ -70,6 +72,11 @@ public class Polyline extends MultiPath implements Serializable {
 	@Override
 	public Geometry.Type getType() {
 		return Type.Polyline;
+	}
+
+	@Override
+	public long estimateMemorySize() {
+		return SIZE_OF_POLYLINE + m_impl.estimateMemorySize();
 	}
 
 	/**

--- a/src/main/java/com/esri/core/geometry/SizeOf.java
+++ b/src/main/java/com/esri/core/geometry/SizeOf.java
@@ -1,0 +1,127 @@
+/*
+ Copyright 1995-2018 Esri
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ For additional information, contact:
+ Environmental Systems Research Institute, Inc.
+ Attn: Contracts Dept
+ 380 New York Street
+ Redlands, California, USA 92373
+
+ email: contracts@esri.com
+ */
+package com.esri.core.geometry;
+
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_CHAR_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_CHAR_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_FLOAT_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_FLOAT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_INT_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_SHORT_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
+
+public final class SizeOf
+{
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_FLOAT = 24;
+
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_DBL = 24;
+
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_INT8 = 24;
+
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_INT16 = 24;
+
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_INT32 = 24;
+
+    public static final int SIZE_OF_ATTRIBUTE_STREAM_OF_INT64 = 24;
+
+    public static final int SIZE_OF_ENVELOPE = 32;
+
+    public static final int SIZE_OF_ENVELOPE2D = 48;
+
+    public static final int SIZE_OF_LINE = 56;
+
+    public static final int SIZE_OF_MULTI_PATH = 24;
+
+    public static final int SIZE_OF_MULTI_PATH_IMPL = 112;
+
+    public static final int SIZE_OF_MULTI_POINT = 24;
+
+    public static final int SIZE_OF_MULTI_POINT_IMPL = 56;
+
+    public static final int SIZE_OF_POINT = 24;
+
+    public static final int SIZE_OF_POLYGON = 24;
+
+    public static final int SIZE_OF_POLYLINE = 24;
+
+    public static final int SIZE_OF_OGC_CONCRETE_GEOMETRY_COLLECTION = 24;
+
+    public static final int SIZE_OF_OGC_LINE_STRING = 24;
+
+    public static final int SIZE_OF_OGC_MULTI_LINE_STRING = 24;
+
+    public static final int SIZE_OF_OGC_MULTI_POINT = 24;
+
+    public static final int SIZE_OF_OGC_MULTI_POLYGON = 24;
+
+    public static final int SIZE_OF_OGC_POINT = 24;
+
+    public static final int SIZE_OF_OGC_POLYGON = 24;
+
+    public static long sizeOfByteArray(int length)
+    {
+        return ARRAY_BYTE_BASE_OFFSET + (((long) ARRAY_BYTE_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfShortArray(int length)
+    {
+        return ARRAY_SHORT_BASE_OFFSET + (((long) ARRAY_SHORT_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfCharArray(int length)
+    {
+        return ARRAY_CHAR_BASE_OFFSET + (((long) ARRAY_CHAR_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfIntArray(int length)
+    {
+        return ARRAY_INT_BASE_OFFSET + (((long) ARRAY_INT_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfLongArray(int length)
+    {
+        return ARRAY_LONG_BASE_OFFSET + (((long) ARRAY_LONG_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfFloatArray(int length)
+    {
+        return ARRAY_FLOAT_BASE_OFFSET + (((long) ARRAY_FLOAT_INDEX_SCALE) * length);
+    }
+
+    public static long sizeOfDoubleArray(int length)
+    {
+        return ARRAY_DOUBLE_BASE_OFFSET + (((long) ARRAY_DOUBLE_INDEX_SCALE) * length);
+    }
+
+    private SizeOf()
+    {
+    }
+}

--- a/src/main/java/com/esri/core/geometry/SpatialReference.java
+++ b/src/main/java/com/esri/core/geometry/SpatialReference.java
@@ -24,13 +24,10 @@
 
 package com.esri.core.geometry;
 
+import com.fasterxml.jackson.core.JsonParser;
+
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-
-import com.esri.core.geometry.SpatialReference;
-import com.esri.core.geometry.SpatialReferenceSerializer;
-import com.esri.core.geometry.VertexDescription;
-import com.fasterxml.jackson.core.JsonParser;
 
 /**
  * A class that represents the spatial reference for the geometry.

--- a/src/main/java/com/esri/core/geometry/SpatialReferenceImpl.java
+++ b/src/main/java/com/esri/core/geometry/SpatialReferenceImpl.java
@@ -25,20 +25,7 @@
 package com.esri.core.geometry;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
-import java.lang.ref.*;
-
-import com.esri.core.geometry.Envelope2D;
-import com.esri.core.geometry.GeoDist;
-import com.esri.core.geometry.GeometryException;
-import com.esri.core.geometry.PeDouble;
-import com.esri.core.geometry.Point;
-import com.esri.core.geometry.Polyline;
-import com.esri.core.geometry.SpatialReference;
-import com.esri.core.geometry.SpatialReferenceImpl;
-import com.esri.core.geometry.VertexDescription.Semantics;
 
 class SpatialReferenceImpl extends SpatialReference {
 	static final boolean no_projection_engine = true;

--- a/src/main/java/com/esri/core/geometry/ogc/OGCConcreteGeometryCollection.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCConcreteGeometryCollection.java
@@ -32,10 +32,13 @@ import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.GeoJsonExportFlags;
 import com.esri.core.geometry.OperatorExportToGeoJson;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_CONCRETE_GEOMETRY_COLLECTION;
 
 public class OGCConcreteGeometryCollection extends OGCGeometryCollection {
 	public OGCConcreteGeometryCollection(List<OGCGeometry> geoms,
@@ -102,6 +105,18 @@ public class OGCConcreteGeometryCollection extends OGCGeometryCollection {
 	@Override
 	public String geometryType() {
 		return "GeometryCollection";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		long size = SIZE_OF_OGC_CONCRETE_GEOMETRY_COLLECTION;
+		if (geometries != null) {
+			for (OGCGeometry geometry : geometries) {
+				size += geometry.estimateMemorySize();
+			}
+		}
+		return size;
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/ogc/OGCGeometry.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCGeometry.java
@@ -24,11 +24,42 @@
 
 package com.esri.core.geometry.ogc;
 
+import com.esri.core.geometry.Envelope;
+import com.esri.core.geometry.Envelope1D;
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.GeometryCursorAppend;
+import com.esri.core.geometry.GeometryEngine;
+import com.esri.core.geometry.JsonParserReader;
+import com.esri.core.geometry.MapGeometry;
+import com.esri.core.geometry.MapOGCStructure;
+import com.esri.core.geometry.MultiPoint;
+import com.esri.core.geometry.NumberUtils;
+import com.esri.core.geometry.OGCStructure;
+import com.esri.core.geometry.Operator;
+import com.esri.core.geometry.OperatorBuffer;
+import com.esri.core.geometry.OperatorConvexHull;
+import com.esri.core.geometry.OperatorExportToGeoJson;
+import com.esri.core.geometry.OperatorExportToWkb;
+import com.esri.core.geometry.OperatorFactoryLocal;
+import com.esri.core.geometry.OperatorImportFromESRIShape;
+import com.esri.core.geometry.OperatorImportFromGeoJson;
+import com.esri.core.geometry.OperatorImportFromWkb;
+import com.esri.core.geometry.OperatorImportFromWkt;
+import com.esri.core.geometry.OperatorIntersection;
+import com.esri.core.geometry.OperatorSimplify;
+import com.esri.core.geometry.OperatorSimplifyOGC;
+import com.esri.core.geometry.OperatorUnion;
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.Polygon;
+import com.esri.core.geometry.Polyline;
+import com.esri.core.geometry.SimpleGeometryCursor;
+import com.esri.core.geometry.SpatialReference;
+import com.esri.core.geometry.VertexDescription;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-
-import com.esri.core.geometry.*;
 
 /**
  * OGC Simple Feature Access specification v.1.2.1
@@ -52,6 +83,17 @@ public abstract class OGCGeometry {
 	}
 
 	abstract public String geometryType();
+
+	/**
+	 * Returns an estimate of this object size in bytes.
+	 * <p>
+	 * This estimate doesn't include the size of the {@link SpatialReference} object
+	 * because instances of {@link SpatialReference} are expected to be shared among
+	 * geometry objects.
+	 *
+	 * @return Returns an estimate of this object size in bytes.
+	 */
+	public abstract long estimateMemorySize();
 
 	public int SRID() {
 		if (esriSR == null)

--- a/src/main/java/com/esri/core/geometry/ogc/OGCLineString.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCLineString.java
@@ -34,9 +34,13 @@ import com.esri.core.geometry.Polyline;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
 import java.nio.ByteBuffer;
 
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_LINE_STRING;
+
 public class OGCLineString extends OGCCurve {
+
 	/**
 	 * The number of Points in this LineString.
 	 */
@@ -114,6 +118,12 @@ public class OGCLineString extends OGCCurve {
 	@Override
 	public String geometryType() {
 		return "LineString";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_LINE_STRING + (multiPath != null ? multiPath.estimateMemorySize() : 0);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/ogc/OGCMultiLineString.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCMultiLineString.java
@@ -36,10 +36,12 @@ import com.esri.core.geometry.Polyline;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
 import java.nio.ByteBuffer;
 
-public class OGCMultiLineString extends OGCMultiCurve {
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_MULTI_LINE_STRING;
 
+public class OGCMultiLineString extends OGCMultiCurve {
 	public OGCMultiLineString(Polyline poly, SpatialReference sr) {
 		polyline = poly;
 		esriSR = sr;
@@ -73,6 +75,12 @@ public class OGCMultiLineString extends OGCMultiCurve {
 	@Override
 	public String geometryType() {
 		return "MultiLineString";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_MULTI_LINE_STRING + (polyline != null ? polyline.estimateMemorySize() : 0);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/ogc/OGCMultiPoint.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCMultiPoint.java
@@ -24,8 +24,6 @@
 
 package com.esri.core.geometry.ogc;
 
-import java.nio.ByteBuffer;
-
 import com.esri.core.geometry.Geometry;
 import com.esri.core.geometry.GeometryEngine;
 import com.esri.core.geometry.MultiPoint;
@@ -36,6 +34,10 @@ import com.esri.core.geometry.Point;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
+import java.nio.ByteBuffer;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_MULTI_POINT;
 
 public class OGCMultiPoint extends OGCGeometryCollection {
 	public int numGeometries() {
@@ -64,6 +66,12 @@ public class OGCMultiPoint extends OGCGeometryCollection {
 	@Override
 	public String geometryType() {
 		return "MultiPoint";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_MULTI_POINT + (multiPoint != null ? multiPoint.estimateMemorySize() : 0);
 	}
 
 	/**

--- a/src/main/java/com/esri/core/geometry/ogc/OGCMultiPolygon.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCMultiPolygon.java
@@ -36,7 +36,10 @@ import com.esri.core.geometry.Polyline;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
 import java.nio.ByteBuffer;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_MULTI_POLYGON;
 
 public class OGCMultiPolygon extends OGCMultiSurface {
 
@@ -87,6 +90,12 @@ public class OGCMultiPolygon extends OGCMultiSurface {
 	@Override
 	public String geometryType() {
 		return "MultiPolygon";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_MULTI_POLYGON + (polygon != null ? polygon.estimateMemorySize() : 0);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/ogc/OGCPoint.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCPoint.java
@@ -24,8 +24,6 @@
 
 package com.esri.core.geometry.ogc;
 
-import java.nio.ByteBuffer;
-
 import com.esri.core.geometry.GeometryEngine;
 import com.esri.core.geometry.MultiPoint;
 import com.esri.core.geometry.Operator;
@@ -35,6 +33,10 @@ import com.esri.core.geometry.Point;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
+import java.nio.ByteBuffer;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_POINT;
 
 public final class OGCPoint extends OGCGeometry {
 	public OGCPoint(Point pt, SpatialReference sr) {
@@ -75,6 +77,12 @@ public final class OGCPoint extends OGCGeometry {
 	@Override
 	public String geometryType() {
 		return "Point";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_POINT + (point != null ? point.estimateMemorySize() : 0);
 	}
 
 	@Override

--- a/src/main/java/com/esri/core/geometry/ogc/OGCPolygon.java
+++ b/src/main/java/com/esri/core/geometry/ogc/OGCPolygon.java
@@ -34,7 +34,10 @@ import com.esri.core.geometry.Polyline;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.WkbExportFlags;
 import com.esri.core.geometry.WktExportFlags;
+
 import java.nio.ByteBuffer;
+
+import static com.esri.core.geometry.SizeOf.SIZE_OF_OGC_POLYGON;
 
 public class OGCPolygon extends OGCSurface {
 	public OGCPolygon(Polygon src, int exteriorRing, SpatialReference sr) {
@@ -107,6 +110,12 @@ public class OGCPolygon extends OGCSurface {
 	@Override
 	public String geometryType() {
 		return "Polygon";
+	}
+
+	@Override
+	public long estimateMemorySize()
+	{
+		return SIZE_OF_OGC_POLYGON + (polygon != null ? polygon.estimateMemorySize() : 0);
 	}
 
 	@Override

--- a/src/test/java/com/esri/core/geometry/TestEstimateMemorySize.java
+++ b/src/test/java/com/esri/core/geometry/TestEstimateMemorySize.java
@@ -1,0 +1,106 @@
+package com.esri.core.geometry;
+
+import com.esri.core.geometry.ogc.OGCConcreteGeometryCollection;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.esri.core.geometry.ogc.OGCLineString;
+import com.esri.core.geometry.ogc.OGCMultiLineString;
+import com.esri.core.geometry.ogc.OGCMultiPoint;
+import com.esri.core.geometry.ogc.OGCMultiPolygon;
+import com.esri.core.geometry.ogc.OGCPoint;
+import com.esri.core.geometry.ogc.OGCPolygon;
+import org.junit.Test;
+// ClassLayout is GPL with Classpath exception, see http://openjdk.java.net/legal/gplv2+ce.html
+import org.openjdk.jol.info.ClassLayout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestEstimateMemorySize
+{
+    @Test
+    public void testInstanceSizes()
+    {
+        assertEquals(getInstanceSize(AttributeStreamOfFloat.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_FLOAT);
+        assertEquals(getInstanceSize(AttributeStreamOfDbl.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_DBL);
+        assertEquals(getInstanceSize(AttributeStreamOfInt8.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT8);
+        assertEquals(getInstanceSize(AttributeStreamOfInt16.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT16);
+        assertEquals(getInstanceSize(AttributeStreamOfInt32.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT32);
+        assertEquals(getInstanceSize(AttributeStreamOfInt64.class), SizeOf.SIZE_OF_ATTRIBUTE_STREAM_OF_INT64);
+        assertEquals(getInstanceSize(Envelope.class), SizeOf.SIZE_OF_ENVELOPE);
+        assertEquals(getInstanceSize(Envelope2D.class), SizeOf.SIZE_OF_ENVELOPE2D);
+        assertEquals(getInstanceSize(Line.class), SizeOf.SIZE_OF_LINE);
+        assertEquals(getInstanceSize(MultiPath.class), SizeOf.SIZE_OF_MULTI_PATH);
+        assertEquals(getInstanceSize(MultiPathImpl.class), SizeOf.SIZE_OF_MULTI_PATH_IMPL);
+        assertEquals(getInstanceSize(MultiPoint.class), SizeOf.SIZE_OF_MULTI_POINT);
+        assertEquals(getInstanceSize(MultiPointImpl.class), SizeOf.SIZE_OF_MULTI_POINT_IMPL);
+        assertEquals(getInstanceSize(Point.class), SizeOf.SIZE_OF_POINT);
+        assertEquals(getInstanceSize(Polygon.class), SizeOf.SIZE_OF_POLYGON);
+        assertEquals(getInstanceSize(Polyline.class), SizeOf.SIZE_OF_POLYLINE);
+        assertEquals(getInstanceSize(OGCConcreteGeometryCollection.class), SizeOf.SIZE_OF_OGC_CONCRETE_GEOMETRY_COLLECTION);
+        assertEquals(getInstanceSize(OGCLineString.class), SizeOf.SIZE_OF_OGC_LINE_STRING);
+        assertEquals(getInstanceSize(OGCMultiLineString.class), SizeOf.SIZE_OF_OGC_MULTI_LINE_STRING);
+        assertEquals(getInstanceSize(OGCMultiPoint.class), SizeOf.SIZE_OF_OGC_MULTI_POINT);
+        assertEquals(getInstanceSize(OGCMultiPolygon.class), SizeOf.SIZE_OF_OGC_MULTI_POLYGON);
+        assertEquals(getInstanceSize(OGCPoint.class), SizeOf.SIZE_OF_OGC_POINT);
+        assertEquals(getInstanceSize(OGCPolygon.class), SizeOf.SIZE_OF_OGC_POLYGON);
+    }
+
+    private static <T> int getInstanceSize(Class<T> clazz)
+    {
+        return ClassLayout.parseClass(clazz).instanceSize();
+    }
+
+    @Test
+    public void testPoint()
+    {
+        testGeometry(parseWkt("POINT (1 2)"));
+    }
+
+    @Test
+    public void testMultiPoint()
+    {
+        testGeometry(parseWkt("MULTIPOINT (0 0, 1 1, 2 3)"));
+    }
+
+    @Test
+    public void testLineString()
+    {
+        testGeometry(parseWkt("LINESTRING (0 1, 2 3, 4 5)"));
+    }
+
+    @Test
+    public void testMultiLineString()
+    {
+        testGeometry(parseWkt("MULTILINESTRING ((0 1, 2 3, 4 5), (1 1, 2 2))"));
+    }
+
+    @Test
+    public void testPolygon()
+    {
+        testGeometry(parseWkt("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"));
+    }
+
+    @Test
+    public void testMultiPolygon()
+    {
+        testGeometry(parseWkt("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"));
+    }
+
+    @Test
+    public void testGeometryCollection()
+    {
+        testGeometry(parseWkt("GEOMETRYCOLLECTION (POINT(4 6), LINESTRING(4 6,7 10))"));
+    }
+
+    private void testGeometry(OGCGeometry geometry)
+    {
+        assertTrue(geometry.estimateMemorySize() > 0);
+    }
+
+    private static OGCGeometry parseWkt(String wkt)
+    {
+        OGCGeometry geometry = OGCGeometry.fromText(wkt);
+        geometry.setSpatialReference(null);
+        return geometry;
+    }
+}


### PR DESCRIPTION
#156

The new OGCGeometry::estimateMemorySize method returns estimates amount of memory used by the object in bytes. Here are the values for some test objects:

```
OGCConcreteGeometryCollection: 426
OGCMultiPolygon: 422
OGCPoint: 80
OGCLineString: 338
OGCPolygon: 354
OGCMultiLineString: 422
OGCMultiPoint: 192
```