### PR TITLE
Fix a typo in usage of Export flags

### DIFF
--- a/src/main/java/com/esri/core/geometry/OperatorExportToWkbLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorExportToWkbLocal.java
@@ -170,7 +170,7 @@ class OperatorExportToWkbLocal extends OperatorExportToWkb {
 		if (!bExportZs && !bExportMs) {
 			type = WkbGeometryType.wkbPolygon;
 
-			if ((exportFlags & WktExportFlags.wktExportPolygon) == 0) {
+			if ((exportFlags & WkbExportFlags.wkbExportPolygon) == 0) {
 				wkbBuffer.put(offset, byteOrder);
 				offset += 1;
 				wkbBuffer.putInt(offset, WkbGeometryType.wkbMultiPolygon);


### PR DESCRIPTION
WktExportFlags.wktExportPolygon is used instead of WkbExportFlags.wkbExportPolygon. They have same value, so there is no bug yet, but it's better to fix that.