### PR TITLE
update jackson to 2.9.6 from 2.9.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
 	<property name="dir.result" value="results" />
 	<property name="dir.root" value="." />
 	<property name="file.jarname" value="esri-geometry-api.jar" />
-	<property name="jackson.version" value="2.9.4" />
+	<property name="jackson.version" value="2.9.6" />
 	<property name="jol.version" value="0.9" />
 	<property name="hamcrest.version" value="1.3" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<java.target.version>1.6</java.target.version>
 
 		<!-- dependency versions -->
-		<jackson.version>2.9.4</jackson.version>
+		<jackson.version>2.9.6</jackson.version>
 		<junit.version>4.12</junit.version>
 		<jol.version>0.9</jol.version>
 


### PR DESCRIPTION
[CVE-2018-7489](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7489)
The deployed version of Jackson would matter more than the compile-dependency version.
Nevertheless, we should use the patched versions for the dependency, which will show up in dependency lists/trees.
cc @mbasmanova 


**Issue**: https://github.com/Esri/geometry-api-java/issues/182