### PR TITLE
Added missing serialization declaration for several classes.

### DIFF
--- a/src/main/java/com/esri/core/geometry/AttributeStreamBase.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamBase.java
@@ -26,12 +26,15 @@
 package com.esri.core.geometry;
 
 import com.esri.core.geometry.VertexDescription.Persistence;
+
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
 /**
  * Base class for AttributeStream instances.
  */
-abstract class AttributeStreamBase {
+abstract class AttributeStreamBase implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	protected boolean m_bLockedInSize;
 	protected boolean m_bReadonly;

--- a/src/main/java/com/esri/core/geometry/QuadTree.java
+++ b/src/main/java/com/esri/core/geometry/QuadTree.java
@@ -25,7 +25,11 @@
 
 package com.esri.core.geometry;
 
-public class QuadTree {
+import java.io.Serializable;
+
+public class QuadTree implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	public static final class QuadTreeIterator {
 		/**
 		 * Resets the iterator to an starting state on the QuadTree. If the

--- a/src/main/java/com/esri/core/geometry/QuadTreeImpl.java
+++ b/src/main/java/com/esri/core/geometry/QuadTreeImpl.java
@@ -23,9 +23,12 @@
  */
 package com.esri.core.geometry;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
-class QuadTreeImpl {
+class QuadTreeImpl implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	static final class QuadTreeIteratorImpl {
 		/**
 		 * Resets the iterator to an starting state on the Quad_tree_impl. If
@@ -1258,7 +1261,9 @@ class QuadTreeImpl {
 	private int m_height_bit_shift = 2;
 	private int m_flushing_count = 5;
 
-	static final class Data {
+	static final class Data implements Serializable {
+		private static final long serialVersionUID = 1L;
+
 		int element;
 		Envelope2D box;
 

--- a/src/main/java/com/esri/core/geometry/StridedIndexTypeCollection.java
+++ b/src/main/java/com/esri/core/geometry/StridedIndexTypeCollection.java
@@ -23,13 +23,17 @@
  */
 package com.esri.core.geometry;
 
+import java.io.Serializable;
+
 /**
  * A collection of strides of Index_type elements. To be used when one needs a
  * collection of homogeneous elements that contain only integer fields (i.e.
  * structs with Index_type members) Recycles the strides. Allows for constant
  * time creation and deletion of an element.
  */
-final class StridedIndexTypeCollection {
+final class StridedIndexTypeCollection implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	private int[][] m_buffer = null;
 	private int m_firstFree = -1;
 	private int m_last = 0;


### PR DESCRIPTION
This is needed in order to be used as part of RDD operations in Spark, via inclusion into RomanIakovlev/timeshape library.