### PR TITLE
Fix NPE on estimateMemorySize against empty multipart geometries

### DIFF
--- a/src/main/java/com/esri/core/geometry/MultiPathImpl.java
+++ b/src/main/java/com/esri/core/geometry/MultiPathImpl.java
@@ -66,8 +66,8 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 			+ (m_envelope != null ? m_envelope.estimateMemorySize() : 0)
 			+ (m_moveToPoint != null ? m_moveToPoint.estimateMemorySize() : 0)
 			+ (m_cachedRingAreas2D != null ? m_cachedRingAreas2D.estimateMemorySize() : 0)
-			+ m_paths.estimateMemorySize()
-			+ m_pathFlags.estimateMemorySize()
+			+ (m_paths != null ? m_paths.estimateMemorySize() : 0)
+			+ (m_pathFlags != null ? m_pathFlags.estimateMemorySize() : 0)
 			+ (m_segmentFlags != null ? m_segmentFlags.estimateMemorySize() : 0)
 			+ (m_segmentParamIndex != null ? m_segmentParamIndex.estimateMemorySize() : 0)
 			+ (m_segmentParams != null ? m_segmentParams.estimateMemorySize() : 0);

--- a/src/test/java/com/esri/core/geometry/TestEstimateMemorySize.java
+++ b/src/test/java/com/esri/core/geometry/TestEstimateMemorySize.java
@@ -78,8 +78,18 @@ public class TestEstimateMemorySize {
 	}
 
 	@Test
+	public void testEmptyPoint() {
+		testGeometry(parseWkt("POINT EMPTY"));
+	}
+
+	@Test
 	public void testMultiPoint() {
 		testGeometry(parseWkt("MULTIPOINT (0 0, 1 1, 2 3)"));
+	}
+
+	@Test
+	public void testEmptyMultiPoint() {
+		testGeometry(parseWkt("MULTIPOINT EMPTY"));
 	}
 
 	@Test
@@ -88,8 +98,18 @@ public class TestEstimateMemorySize {
 	}
 
 	@Test
+	public void testEmptyLineString() {
+		testGeometry(parseWkt("LINESTRING EMPTY"));
+	}
+
+	@Test
 	public void testMultiLineString() {
 		testGeometry(parseWkt("MULTILINESTRING ((0 1, 2 3, 4 5), (1 1, 2 2))"));
+	}
+
+	@Test
+	public void testEmptyMultiLineString() {
+		testGeometry(parseWkt("MULTILINESTRING EMPTY"));
 	}
 
 	@Test
@@ -98,13 +118,28 @@ public class TestEstimateMemorySize {
 	}
 
 	@Test
+	public void testEmptyPolygon() {
+		testGeometry(parseWkt("POLYGON EMPTY"));
+	}
+
+	@Test
 	public void testMultiPolygon() {
 		testGeometry(parseWkt("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"));
 	}
 
 	@Test
+	public void testEmptyMultiPolygon() {
+		testGeometry(parseWkt("MULTIPOLYGON EMPTY"));
+	}
+
+	@Test
 	public void testGeometryCollection() {
 		testGeometry(parseWkt("GEOMETRYCOLLECTION (POINT(4 6), LINESTRING(4 6,7 10))"));
+	}
+
+	@Test
+	public void testEmptyGeometryCollection() {
+		testGeometry(parseWkt("GEOMETRYCOLLECTION EMPTY"));
 	}
 
 	private void testGeometry(OGCGeometry geometry) {


### PR DESCRIPTION
This commit fixes an NPE in the estimateMemorySize method when the following geometries are empty:
- LINESTRING
- MULTILINESTRING
- GEOMETRY
- MULTIGEOMETRY
It also adds test "empty" versions the current unit test suite.