### PR TITLE
Move ScanCallback#estimateMemorySize to implementation

### DIFF
--- a/src/main/java/com/esri/core/geometry/RasterizedGeometry2DImpl.java
+++ b/src/main/java/com/esri/core/geometry/RasterizedGeometry2DImpl.java
@@ -86,7 +86,11 @@ final class RasterizedGeometry2DImpl extends RasterizedGeometry2D {
 			}
 		}
 
-		@Override
+		/**
+		 * Returns an estimate of this object size in bytes.
+		 *
+		 * @return Returns an estimate of this object size in bytes.
+		 */
 		public long estimateMemorySize()
 		{
 			return SIZE_OF_SCAN_CALLBACK_IMPL +

--- a/src/main/java/com/esri/core/geometry/SimpleRasterizer.java
+++ b/src/main/java/com/esri/core/geometry/SimpleRasterizer.java
@@ -56,13 +56,6 @@ public class SimpleRasterizer {
 		 * @param scanCount3 The number of initialized elements in the scans array. The scan count is scanCount3 / 3. 
 		 */
 		void drawScan(int[] scans, int scanCount3);
-
-		/**
-		 * Returns an estimate of this object size in bytes.
-		 *
-		 * @return Returns an estimate of this object size in bytes.
-		 */
-		long estimateMemorySize();
 	}
 	
 	public SimpleRasterizer() {


### PR DESCRIPTION
Move `estimateMemorySize` from interface to implementation to avoid changing public interface.

See #208