### PR TITLE
Fixed the calculation of firstSign

### DIFF
--- a/src/main/java/com/esri/core/geometry/MultiPathImpl.java
+++ b/src/main/java/com/esri/core/geometry/MultiPathImpl.java
@@ -505,7 +505,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	// Reviewed vs. Native Jan 11, 2011
 	/**
 	 * Returns the size of the segment data for the given segment type.
-	 * 
+	 *
 	 * @param flag
 	 *            is one of the segment flags from the SegmentFlags enum.
 	 * @return the size of the segment params as the number of doubles.
@@ -517,7 +517,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	// Reviewed vs. Native Jan 11, 2011
 	/**
 	 * Closes last path of the MultiPathImpl with the Bezier Segment.
-	 * 
+	 *
 	 * The start point of the Bezier is the last point of the path and the last
 	 * point of the bezier is the first point of the path.
 	 */
@@ -615,7 +615,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	// Reviewed vs. Native Jan 11, 2011
 	/**
 	 * adds a rectangular closed Path to the MultiPathImpl.
-	 * 
+	 *
 	 * @param envSrc
 	 *            is the source rectangle.
 	 * @param bReverse
@@ -648,7 +648,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	// Reviewed vs. Native Jan 11, 2011
 	/**
 	 * adds a rectangular closed Path to the MultiPathImpl.
-	 * 
+	 *
 	 * @param envSrc
 	 *            is the source rectangle.
 	 * @param bReverse
@@ -1872,7 +1872,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 		dstPoly.m_bPathStarted = false;
 		dstPoly.m_curveParamwritePoint = m_curveParamwritePoint;
 		dstPoly.m_fill_rule = m_fill_rule;
-		
+
 		if (m_paths != null)
 			dstPoly.m_paths = new AttributeStreamOfInt32(m_paths);
 		else
@@ -1968,7 +1968,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 					return false;
 			}
 		}
-	      
+
 		return super.equals(other);
 	}
 
@@ -2062,8 +2062,10 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 		if (!_hasDirtyFlag(DirtyFlags.DirtyOGCFlags))
 			return (m_pathFlags.read(ringIndex) & (byte) PathFlags.enumOGCStartPolygon) != 0;
 
-		_updateRingAreas2D();
-		return m_cachedRingAreas2D.read(ringIndex) > 0;
+		_updateOGCFlags();
+		return (m_pathFlags.read(ringIndex) & (byte) PathFlags.enumOGCStartPolygon) != 0;
+        //_updateRingAreas2D();
+		//return m_cachedRingAreas2D.read(ringIndex) > 0;
 		// Should we make a function called _UpdateHasNonLinearSegmentsFlags and
 		// call it here?
 	}
@@ -2139,12 +2141,12 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 				m_pathFlags = (AttributeStreamOfInt8) AttributeStreamBase
 						.createByteStream(pathCount + 1);
 
-			int firstSign = 1;
+			float firstSign = 1;
 			for (int ipath = 0; ipath < pathCount; ipath++) {
 				double area = m_cachedRingAreas2D.read(ipath);
 				if (ipath == 0)
-					firstSign = area > 0 ? 1 : -1;
-				if (area * firstSign > 0.0)
+					firstSign = area >= 0.0 ? 1f : -1f;
+				if (area * firstSign >= 0.0)
 					m_pathFlags.setBits(ipath,
 							(byte) PathFlags.enumOGCStartPolygon);
 				else
@@ -2287,7 +2289,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	/**
 	 * Returns a reference to the AttributeStream of MultiPathImpl parts
 	 * (Paths).
-	 * 
+	 *
 	 * For the non empty MultiPathImpl, that stream contains start points of the
 	 * MultiPathImpl curves. In addition, the last element is the total point
 	 * count. The number of vertices in a given part is parts[i + 1] - parts[i].
@@ -2308,7 +2310,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	/**
 	 * Returns a reference to the AttributeStream of Segment flags (SegmentFlags
 	 * flags). Can be NULL when no non-linear segments are present.
-	 * 
+	 *
 	 * Segment flags indicate what kind of segment originates (starts) on the
 	 * given point. The last vertices of open Path parts has enumNone flag.
 	 */
@@ -2320,7 +2322,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 	/**
 	 * Returns a reference to the AttributeStream of Path flags (PathFlags
 	 * flags).
-	 * 
+	 *
 	 * Each start point of a path has a flag set to indicate if the Path is open
 	 * or closed.
 	 */
@@ -2569,7 +2571,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 			envelope.setCoords(env);
 		}
 	}
-	
+
 	@Override
 	public boolean _buildQuadTreeAccelerator(GeometryAccelerationDegree d) {
 		if (m_accelerators == null)// (!m_accelerators)
@@ -2612,8 +2614,7 @@ final class MultiPathImpl extends MultiVertexGeometryImpl {
 		return m_fill_rule;
 	}
 
-	void clearDirtyOGCFlags() { 
+	void clearDirtyOGCFlags() {
 		_setDirtyFlag(DirtyFlags.DirtyOGCFlags, false);
 	}
 }
-

--- a/src/test/java/com/esri/core/geometry/TestPolygon.java
+++ b/src/test/java/com/esri/core/geometry/TestPolygon.java
@@ -1103,10 +1103,10 @@ public class TestPolygon extends TestCase {
 
 		Line line = new Line();
 		line.toString();
-		
+
 		line.setStart(new Point(0, 0));
 		line.setEnd(new Point(1, 0));
-		
+
 		line.toString();
 
 		double geoLength = GeometryEngine.geodesicDistanceOnWGS84(new Point(0,
@@ -1152,7 +1152,7 @@ public class TestPolygon extends TestCase {
 
 		assertTrue(noException);
 	}// end of method
-	
+
 	@Test
 	public void testBoundary() {
 		Geometry g = OperatorImportFromWkt
@@ -1170,7 +1170,7 @@ public class TestPolygon extends TestCase {
 		assertTrue(s
 				.equals("MULTILINESTRING ((-10 -10, 10 -10, 10 10, -10 10, -10 -10), (-5 -5, -5 5, 5 5, 5 -5, -5 -5))"));
 	}
-	
+
 	@Test
 	public void testReplaceNaNs() {
 		{
@@ -1183,7 +1183,7 @@ public class TestPolygon extends TestCase {
 		pt.setXY(11, 12);
 		pt.setZ(3);
 		mp.add(pt);
-		
+
 		mp.replaceNaNs(VertexDescription.Semantics.Z, 5);
 		assertTrue(mp.getPoint(0).equals(new Point(1, 2, 5)));
 		assertTrue(mp.getPoint(1).equals(new Point(11, 12, 3)));
@@ -1199,12 +1199,12 @@ public class TestPolygon extends TestCase {
 		pt.setXY(11, 12);
 		pt.setZ(3);
 		mp.lineTo(pt);
-		
+
 		mp.replaceNaNs(VertexDescription.Semantics.Z, 5);
 		assertTrue(mp.getPoint(0).equals(new Point(1, 2, 5)));
 		assertTrue(mp.getPoint(1).equals(new Point(11, 12, 3)));
 		}
-		
+
 		{
 		Polygon mp = new Polygon();
 		Point pt = new Point();
@@ -1215,7 +1215,7 @@ public class TestPolygon extends TestCase {
 		pt.setXY(11, 12);
 		pt.setM(3);
 		mp.lineTo(pt);
-		
+
 		mp.replaceNaNs(VertexDescription.Semantics.M, 5);
 		Point p = new Point(1, 2); p.setM(5);
 		boolean b = mp.getPoint(0).equals(p);
@@ -1224,7 +1224,7 @@ public class TestPolygon extends TestCase {
 		b = mp.getPoint(1).equals(p);
 		assertTrue(b);
 		}
-		
+
 	}
 
 	@Test
@@ -1316,6 +1316,28 @@ public class TestPolygon extends TestCase {
 		}
 		assertEquals(paths, 3);
 		assertEquals(segments, 15);
+	}
+
+	@Test
+	public void testIsExteriorRing() {
+		{
+			Polygon poly = new Polygon();
+			poly.startPath(0, 0);
+			poly.lineTo(0, 1);
+			poly.lineTo(1, 1);
+			poly.lineTo(1, 0);
+			assertTrue(poly.isExteriorRing(0));
+		}
+
+		{
+			Polygon poly = new Polygon();
+			poly.startPath(-135, 85);
+			poly.lineTo(-45, 85);
+			poly.lineTo(45, 85);
+			poly.lineTo(135, 85);
+			assertTrue(poly.isExteriorRing(0));
+		}
+
 	}
 
 	private static Polygon birmingham() {


### PR DESCRIPTION
For polygons with an "area" of 0 (eg. in spherical geometry polygons defining by spherical cap), the area ends up being positive 0, but firstSign ends up being negative. Using signum seems more appropriate, as it will always be of the sign of area.
This is important as the first part of such polygon would end up not being an exterior ring