### PR TITLE
Improve numerical stability for polygon centroids

### DIFF
--- a/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
@@ -23,6 +23,7 @@
  */
 package com.esri.core.geometry;
 
+import static java.lang.Math.abs;
 import static java.lang.Math.sqrt;
 
 public class OperatorCentroid2DLocal extends OperatorCentroid2D
@@ -148,6 +149,10 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D
         double xSum = 0;
         double ySum = 0;
         double signedArea = 0;
+        double xMin = Double.POSITIVE_INFINITY;
+        double yMin = Double.POSITIVE_INFINITY;
+        double xMax = Double.NEGATIVE_INFINITY;
+        double yMax = Double.NEGATIVE_INFINITY;
 
         Point2D current = new Point2D();
         Point2D next = new Point2D();
@@ -158,6 +163,16 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D
             xSum += (current.x + next.x) * ladder;
             ySum += (current.y + next.y) * ladder;
             signedArea += ladder / 2;
+            xMin = Math.min(xMin, current.x);
+            yMin = Math.min(yMin, current.y);
+            xMax = Math.max(xMax, current.x);
+            yMax = Math.max(yMax, current.y);
+        }
+        if (abs(signedArea) < Double.MIN_NORMAL) {
+            // Handle degenerate cases with ~0 area by the bounding box centroid.
+            // By this point we've already handled the empty case, so we won't
+            // have infinities.
+            return new Point2D((xMin + xMax) / 2, (yMin + yMax) / 2);
         }
         return new Point2D(xSum / (signedArea * 6), ySum / (signedArea * 6));
     }

--- a/src/test/java/com/esri/core/geometry/TestCentroid.java
+++ b/src/test/java/com/esri/core/geometry/TestCentroid.java
@@ -105,11 +105,40 @@ public class TestCentroid
         assertCentroid(new Polygon(), null);
     }
 
+    @Test
+    public void testCentroidForNumericalStability() {
+        Polygon polygon = new Polygon();
+        polygon.startPath(153.492818, -28.13729);
+        polygon.lineTo(153.492821, -28.137291);
+        polygon.lineTo(153.492816, -28.137289);
+        polygon.lineTo(153.492818, -28.13729);
+        assertCentroid(polygon, new Point2D(153.49281, -28.13729), 1e-5);
+
+        polygon = new Polygon();
+        polygon.startPath(153.112475, -28.360526);
+        polygon.lineTo(153.1124759, -28.360527);
+        polygon.lineTo(153.1124759, -28.360526);
+        polygon.lineTo(153.112475, -28.360526);
+        assertCentroid(polygon, new Point2D(153.112475, -28.360526), 1e-6);
+    }
+
     private static void assertCentroid(Geometry geometry, Point2D expectedCentroid)
+    {
+        assertCentroid(geometry, expectedCentroid, Double.MIN_NORMAL);
+    }
+
+    private static void assertCentroid(Geometry geometry, Point2D expectedCentroid, double epsilon)
     {
         OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance().getOperator(Operator.Type.Centroid2D);
 
         Point2D actualCentroid = operator.execute(geometry, null);
-        Assert.assertEquals(expectedCentroid, actualCentroid);
+        if (expectedCentroid == null || actualCentroid == null) {
+            // If one is null, they must both be null
+            Assert.assertEquals(expectedCentroid, actualCentroid);
+        } else {
+            // Neither is null and their xy coords should be within precision
+            Assert.assertEquals(expectedCentroid.x, actualCentroid.x, epsilon);
+            Assert.assertEquals(expectedCentroid.y, actualCentroid.y, epsilon);
+        }
     }
 }


### PR DESCRIPTION
In cases where the polygon has near-0 area (eg, when it's degenerate and
nearly 1-dimensional), the returned centroids would have infinite
coordinates.  This checks for those conditions, and replaces the
centroid with the bounding-box centroid, which is a good approximation.