### PR TITLE
centroid fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 target/*
 /bin/
 /target/
+
+.metadata/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
-    - openjdk7
-    - openjdk8
+    - openjdk9
+    - openjdk10
+    - openjdk14
     - oraclejdk8
     - oraclejdk9
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk:
     - openjdk9
     - openjdk10
     - openjdk14
-    - oraclejdk9
-    - oraclejdk10
+#    - oraclejdk9
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
     - openjdk9
     - openjdk10
     - openjdk14
-    - oraclejdk8
     - oraclejdk9
+    - oraclejdk10
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ jdk:
     - openjdk10
     - openjdk14
 #    - oraclejdk9
+    - oraclejdk11
 notifications:
     email: false

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.2</version>
+				<version>1.6.8</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<java.source.version>1.6</java.source.version>
-		<java.target.version>1.6</java.target.version>
+		<java.source.version>1.7</java.source.version>
+		<java.target.version>1.7</java.target.version>
 
 		<!-- dependency versions -->
 		<jackson.version>2.9.6</jackson.version>

--- a/src/main/java/com/esri/core/geometry/OperatorCentroid2D.java
+++ b/src/main/java/com/esri/core/geometry/OperatorCentroid2D.java
@@ -23,18 +23,15 @@
  */
 package com.esri.core.geometry;
 
-public abstract class OperatorCentroid2D extends Operator
-{
-    @Override
-    public Type getType()
-    {
-        return Type.Centroid2D;
-    }
+public abstract class OperatorCentroid2D extends Operator {
+	@Override
+	public Type getType() {
+		return Type.Centroid2D;
+	}
 
-    public abstract Point2D execute(Geometry geometry, ProgressTracker progressTracker);
+	public abstract Point2D execute(Geometry geometry, ProgressTracker progressTracker);
 
-    public static OperatorCentroid2D local()
-    {
-        return (OperatorCentroid2D) OperatorFactoryLocal.getInstance().getOperator(Type.Centroid2D);
-    }
+	public static OperatorCentroid2D local() {
+		return (OperatorCentroid2D) OperatorFactoryLocal.getInstance().getOperator(Type.Centroid2D);
+	}
 }

--- a/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
@@ -102,8 +102,14 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D {
 	// 0 to N - 1) / (6 * signedArea)
 	private static Point2D computePolygonCentroid(Polygon polygon) {
 		double totalArea = polygon.calculateArea2D();
+		if (totalArea == 0)
+		{
+			return computePolylineCentroid(polygon);
+		}
+		
 		MathUtils.KahanSummator xSum = new MathUtils.KahanSummator(0);
 		MathUtils.KahanSummator ySum = new MathUtils.KahanSummator(0);
+		Point2D startPoint = new Point2D();
 		Point2D current = new Point2D();
 		Point2D next = new Point2D();
 		Point2D origin = polygon.getXY(0);
@@ -116,16 +122,23 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D {
 				continue;
 			}
 			
-			polygon.getXY(startIndex, current);
-			current.sub(origin);
-			for (int i = startIndex + 1; i < endIndex; i++) {
+			polygon.getXY(startIndex, startPoint);
+			polygon.getXY(startIndex + 1, current);
+			current.sub(startPoint);
+			for (int i = startIndex + 2, n = endIndex; i < n; i++) {
 				polygon.getXY(i, next);
-				next.sub(origin);
+				next.sub(startPoint);
 				double twiceTriangleArea = next.x * current.y - current.x * next.y;
 				xSum.add((current.x + next.x) * twiceTriangleArea);
 				ySum.add((current.y + next.y) * twiceTriangleArea);
 				current.setCoords(next);
 			}
+			
+			startPoint.sub(origin);
+			startPoint.scale(6.0 * polygon.calculateRingArea2D(ipath));
+			//add weighted startPoint
+			xSum.add(startPoint.x);
+			ySum.add(startPoint.y);
 		}
 
 		totalArea *= 6.0;

--- a/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
@@ -25,140 +25,135 @@ package com.esri.core.geometry;
 
 import static java.lang.Math.sqrt;
 
-public class OperatorCentroid2DLocal extends OperatorCentroid2D
-{
-    @Override
-    public Point2D execute(Geometry geometry, ProgressTracker progressTracker)
-    {
-        if (geometry.isEmpty()) {
-            return null;
-        }
+public class OperatorCentroid2DLocal extends OperatorCentroid2D {
+	@Override
+	public Point2D execute(Geometry geometry, ProgressTracker progressTracker) {
+		if (geometry.isEmpty()) {
+			return null;
+		}
 
-        Geometry.Type geometryType = geometry.getType();
-        switch (geometryType) {
-            case Point:
-                return ((Point) geometry).getXY();
-            case Line:
-                return computeLineCentroid((Line) geometry);
-            case Envelope:
-                return ((Envelope) geometry).getCenterXY();
-            case MultiPoint:
-                return computePointsCentroid((MultiPoint) geometry);
-            case Polyline:
-                return computePolylineCentroid(((Polyline) geometry));
-            case Polygon:
-                return computePolygonCentroid((Polygon) geometry);
-            default:
-                throw new UnsupportedOperationException("Unexpected geometry type: " + geometryType);
-        }
-    }
+		Geometry.Type geometryType = geometry.getType();
+		switch (geometryType) {
+		case Point:
+			return ((Point) geometry).getXY();
+		case Line:
+			return computeLineCentroid((Line) geometry);
+		case Envelope:
+			return ((Envelope) geometry).getCenterXY();
+		case MultiPoint:
+			return computePointsCentroid((MultiPoint) geometry);
+		case Polyline:
+			return computePolylineCentroid(((Polyline) geometry));
+		case Polygon:
+			return computePolygonCentroid((Polygon) geometry);
+		default:
+			throw new UnsupportedOperationException("Unexpected geometry type: " + geometryType);
+		}
+	}
 
-    private static Point2D computeLineCentroid(Line line)
-    {
-        return new Point2D((line.getEndX() - line.getStartX()) / 2, (line.getEndY() - line.getStartY()) / 2);
-    }
+	private static Point2D computeLineCentroid(Line line) {
+		return new Point2D((line.getEndX() - line.getStartX()) / 2, (line.getEndY() - line.getStartY()) / 2);
+	}
 
-    // Points centroid is arithmetic mean of the input points
-    private static Point2D computePointsCentroid(MultiPoint multiPoint)
-    {
-        double xSum = 0;
-        double ySum = 0;
-        int pointCount = multiPoint.getPointCount();
-        Point2D point2D = new Point2D();
-        for (int i = 0; i < pointCount; i++) {
-            multiPoint.getXY(i, point2D);
-            xSum += point2D.x;
-            ySum += point2D.y;
-        }
-        return new Point2D(xSum / pointCount, ySum / pointCount);
-    }
+	// Points centroid is arithmetic mean of the input points
+	private static Point2D computePointsCentroid(MultiPoint multiPoint) {
+		double xSum = 0;
+		double ySum = 0;
+		int pointCount = multiPoint.getPointCount();
+		Point2D point2D = new Point2D();
+		for (int i = 0; i < pointCount; i++) {
+			multiPoint.getXY(i, point2D);
+			xSum += point2D.x;
+			ySum += point2D.y;
+		}
+		return new Point2D(xSum / pointCount, ySum / pointCount);
+	}
 
-    // Lines centroid is weighted mean of each line segment, weight in terms of line length
-    private static Point2D computePolylineCentroid(Polyline polyline)
-    {
-        double xSum = 0;
-        double ySum = 0;
-        double weightSum = 0;
+	// Lines centroid is weighted mean of each line segment, weight in terms of line
+	// length
+	private static Point2D computePolylineCentroid(Polyline polyline) {
+		double xSum = 0;
+		double ySum = 0;
+		double weightSum = 0;
 
-        Point2D startPoint = new Point2D();
-        Point2D endPoint = new Point2D();
-        for (int i = 0; i < polyline.getPathCount(); i++) {
-            polyline.getXY(polyline.getPathStart(i), startPoint);
-            polyline.getXY(polyline.getPathEnd(i) - 1, endPoint);
-            double dx = endPoint.x - startPoint.x;
-            double dy = endPoint.y - startPoint.y;
-            double length = sqrt(dx * dx + dy * dy);
-            weightSum += length;
-            xSum += (startPoint.x + endPoint.x) * length / 2;
-            ySum += (startPoint.y + endPoint.y) * length / 2;
-        }
-        return new Point2D(xSum / weightSum, ySum / weightSum);
-    }
+		Point2D startPoint = new Point2D();
+		Point2D endPoint = new Point2D();
+		for (int i = 0; i < polyline.getPathCount(); i++) {
+			polyline.getXY(polyline.getPathStart(i), startPoint);
+			polyline.getXY(polyline.getPathEnd(i) - 1, endPoint);
+			double dx = endPoint.x - startPoint.x;
+			double dy = endPoint.y - startPoint.y;
+			double length = sqrt(dx * dx + dy * dy);
+			weightSum += length;
+			xSum += (startPoint.x + endPoint.x) * length / 2;
+			ySum += (startPoint.y + endPoint.y) * length / 2;
+		}
+		return new Point2D(xSum / weightSum, ySum / weightSum);
+	}
 
-    // Polygon centroid: area weighted average of centroids in case of holes
-    private static Point2D computePolygonCentroid(Polygon polygon)
-    {
-        int pathCount = polygon.getPathCount();
+	// Polygon centroid: area weighted average of centroids in case of holes
+	private static Point2D computePolygonCentroid(Polygon polygon) {
+		int pathCount = polygon.getPathCount();
 
-        if (pathCount == 1) {
-            return getPolygonSansHolesCentroid(polygon);
-        }
+		if (pathCount == 1) {
+			return getPolygonSansHolesCentroid(polygon);
+		}
 
-        double xSum = 0;
-        double ySum = 0;
-        double areaSum = 0;
+		double xSum = 0;
+		double ySum = 0;
+		double areaSum = 0;
 
-        for (int i = 0; i < pathCount; i++) {
-            int startIndex = polygon.getPathStart(i);
-            int endIndex = polygon.getPathEnd(i);
+		for (int i = 0; i < pathCount; i++) {
+			int startIndex = polygon.getPathStart(i);
+			int endIndex = polygon.getPathEnd(i);
 
-            Polygon sansHoles = getSubPolygon(polygon, startIndex, endIndex);
+			Polygon sansHoles = getSubPolygon(polygon, startIndex, endIndex);
 
-            Point2D centroid = getPolygonSansHolesCentroid(sansHoles);
-            double area = sansHoles.calculateArea2D();
+			Point2D centroid = getPolygonSansHolesCentroid(sansHoles);
+			double area = sansHoles.calculateArea2D();
 
-            xSum += centroid.x * area;
-            ySum += centroid.y * area;
-            areaSum += area;
-        }
+			xSum += centroid.x * area;
+			ySum += centroid.y * area;
+			areaSum += area;
+		}
 
-        return new Point2D(xSum / areaSum, ySum / areaSum);
-    }
+		return new Point2D(xSum / areaSum, ySum / areaSum);
+	}
 
-    private static Polygon getSubPolygon(Polygon polygon, int startIndex, int endIndex)
-    {
-        Polyline boundary = new Polyline();
-        boundary.startPath(polygon.getPoint(startIndex));
-        for (int i = startIndex + 1; i < endIndex; i++) {
-            Point current = polygon.getPoint(i);
-            boundary.lineTo(current);
-        }
+	private static Polygon getSubPolygon(Polygon polygon, int startIndex, int endIndex) {
+		Polyline boundary = new Polyline();
+		boundary.startPath(polygon.getPoint(startIndex));
+		for (int i = startIndex + 1; i < endIndex; i++) {
+			Point current = polygon.getPoint(i);
+			boundary.lineTo(current);
+		}
 
-        final Polygon newPolygon = new Polygon();
-        newPolygon.add(boundary, false);
-        return newPolygon;
-    }
+		final Polygon newPolygon = new Polygon();
+		newPolygon.add(boundary, false);
+		return newPolygon;
+	}
 
-    // Polygon sans holes centroid:
-    // c[x] = (Sigma(x[i] + x[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i = 0 to N - 1) / (6 * signedArea)
-    // c[y] = (Sigma(y[i] + y[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i = 0 to N - 1) / (6 * signedArea)
-    private static Point2D getPolygonSansHolesCentroid(Polygon polygon)
-    {
-        int pointCount = polygon.getPointCount();
-        double xSum = 0;
-        double ySum = 0;
-        double signedArea = 0;
+	// Polygon sans holes centroid:
+	// c[x] = (Sigma(x[i] + x[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i =
+	// 0 to N - 1) / (6 * signedArea)
+	// c[y] = (Sigma(y[i] + y[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i =
+	// 0 to N - 1) / (6 * signedArea)
+	private static Point2D getPolygonSansHolesCentroid(Polygon polygon) {
+		int pointCount = polygon.getPointCount();
+		double xSum = 0;
+		double ySum = 0;
+		double signedArea = 0;
 
-        Point2D current = new Point2D();
-        Point2D next = new Point2D();
-        for (int i = 0; i < pointCount; i++) {
-            polygon.getXY(i, current);
-            polygon.getXY((i + 1) % pointCount, next);
-            double ladder = current.x * next.y - next.x * current.y;
-            xSum += (current.x + next.x) * ladder;
-            ySum += (current.y + next.y) * ladder;
-            signedArea += ladder / 2;
-        }
-        return new Point2D(xSum / (signedArea * 6), ySum / (signedArea * 6));
-    }
+		Point2D current = new Point2D();
+		Point2D next = new Point2D();
+		for (int i = 0; i < pointCount; i++) {
+			polygon.getXY(i, current);
+			polygon.getXY((i + 1) % pointCount, next);
+			double ladder = current.x * next.y - next.x * current.y;
+			xSum += (current.x + next.x) * ladder;
+			ySum += (current.y + next.y) * ladder;
+			signedArea += ladder / 2;
+		}
+		return new Point2D(xSum / (signedArea * 6), ySum / (signedArea * 6));
+	}
 }

--- a/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java
@@ -56,7 +56,7 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D {
 	}
 
 	// Points centroid is arithmetic mean of the input points
-	private static Point2D computePointsCentroid(MultiPoint multiPoint) {
+	private static Point2D computePointsCentroid(MultiVertexGeometry multiPoint) {
 		double xSum = 0;
 		double ySum = 0;
 		int pointCount = multiPoint.getPointCount();
@@ -71,89 +71,66 @@ public class OperatorCentroid2DLocal extends OperatorCentroid2D {
 
 	// Lines centroid is weighted mean of each line segment, weight in terms of line
 	// length
-	private static Point2D computePolylineCentroid(Polyline polyline) {
-		double xSum = 0;
-		double ySum = 0;
-		double weightSum = 0;
-
-		Point2D startPoint = new Point2D();
-		Point2D endPoint = new Point2D();
-		for (int i = 0; i < polyline.getPathCount(); i++) {
-			polyline.getXY(polyline.getPathStart(i), startPoint);
-			polyline.getXY(polyline.getPathEnd(i) - 1, endPoint);
-			double dx = endPoint.x - startPoint.x;
-			double dy = endPoint.y - startPoint.y;
-			double length = sqrt(dx * dx + dy * dy);
-			weightSum += length;
-			xSum += (startPoint.x + endPoint.x) * length / 2;
-			ySum += (startPoint.y + endPoint.y) * length / 2;
+	private static Point2D computePolylineCentroid(MultiPath polyline) {
+		double totalLength = polyline.calculateLength2D();
+		if (totalLength == 0) {
+			return computePointsCentroid(polyline);
 		}
-		return new Point2D(xSum / weightSum, ySum / weightSum);
+		
+		MathUtils.KahanSummator xSum = new MathUtils.KahanSummator(0);
+		MathUtils.KahanSummator ySum = new MathUtils.KahanSummator(0);
+		Point2D point = new Point2D();
+		SegmentIterator iter = polyline.querySegmentIterator();
+		while (iter.nextPath()) {
+			while (iter.hasNextSegment()) {
+				Segment seg = iter.nextSegment();
+				seg.getCoord2D(0.5, point);
+				double length = seg.calculateLength2D();
+				point.scale(length);
+				xSum.add(point.x);
+				ySum.add(point.y);
+			}
+		}
+		
+		return new Point2D(xSum.getResult() / totalLength, ySum.getResult() / totalLength);
 	}
 
-	// Polygon centroid: area weighted average of centroids in case of holes
-	private static Point2D computePolygonCentroid(Polygon polygon) {
-		int pathCount = polygon.getPathCount();
-
-		if (pathCount == 1) {
-			return getPolygonSansHolesCentroid(polygon);
-		}
-
-		double xSum = 0;
-		double ySum = 0;
-		double areaSum = 0;
-
-		for (int i = 0; i < pathCount; i++) {
-			int startIndex = polygon.getPathStart(i);
-			int endIndex = polygon.getPathEnd(i);
-
-			Polygon sansHoles = getSubPolygon(polygon, startIndex, endIndex);
-
-			Point2D centroid = getPolygonSansHolesCentroid(sansHoles);
-			double area = sansHoles.calculateArea2D();
-
-			xSum += centroid.x * area;
-			ySum += centroid.y * area;
-			areaSum += area;
-		}
-
-		return new Point2D(xSum / areaSum, ySum / areaSum);
-	}
-
-	private static Polygon getSubPolygon(Polygon polygon, int startIndex, int endIndex) {
-		Polyline boundary = new Polyline();
-		boundary.startPath(polygon.getPoint(startIndex));
-		for (int i = startIndex + 1; i < endIndex; i++) {
-			Point current = polygon.getPoint(i);
-			boundary.lineTo(current);
-		}
-
-		final Polygon newPolygon = new Polygon();
-		newPolygon.add(boundary, false);
-		return newPolygon;
-	}
-
-	// Polygon sans holes centroid:
+	// Polygon centroid: area weighted average of centroids:
 	// c[x] = (Sigma(x[i] + x[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i =
 	// 0 to N - 1) / (6 * signedArea)
 	// c[y] = (Sigma(y[i] + y[i + 1]) * (x[i] * y[i + 1] - x[i + 1] * y[i]), for i =
 	// 0 to N - 1) / (6 * signedArea)
-	private static Point2D getPolygonSansHolesCentroid(Polygon polygon) {
-		int pointCount = polygon.getPointCount();
-		double xSum = 0;
-		double ySum = 0;
-		double signedArea = 0;
-
+	private static Point2D computePolygonCentroid(Polygon polygon) {
+		double totalArea = polygon.calculateArea2D();
+		MathUtils.KahanSummator xSum = new MathUtils.KahanSummator(0);
+		MathUtils.KahanSummator ySum = new MathUtils.KahanSummator(0);
 		Point2D current = new Point2D();
 		Point2D next = new Point2D();
-		for (int i = 0; i < pointCount; i++) {
-			polygon.getXY(i, current);
-			polygon.getXY((i + 1) % pointCount, next);
-			double ladder = current.x * next.y - next.x * current.y;
-			xSum += (current.x + next.x) * ladder;
-			ySum += (current.y + next.y) * ladder;
-			signedArea += ladder / 2;
+		Point2D origin = polygon.getXY(0);
+
+		for (int ipath = 0, npaths = polygon.getPathCount(); ipath < npaths; ipath++) {
+			int startIndex = polygon.getPathStart(ipath);
+			int endIndex = polygon.getPathEnd(ipath);
+			int pointCount = endIndex - startIndex;
+			if (pointCount < 3) {
+				continue;
+			}
+			
+			polygon.getXY(startIndex, current);
+			current.sub(origin);
+			for (int i = startIndex + 1; i < endIndex; i++) {
+				polygon.getXY(i, next);
+				next.sub(origin);
+				double twiceTriangleArea = next.x * current.y - current.x * next.y;
+				xSum.add((current.x + next.x) * twiceTriangleArea);
+				ySum.add((current.y + next.y) * twiceTriangleArea);
+				current.setCoords(next);
+			}
 		}
-		return new Point2D(xSum / (signedArea * 6), ySum / (signedArea * 6));
+
+		totalArea *= 6.0;
+		Point2D res = new Point2D(xSum.getResult() / totalArea, ySum.getResult() / totalArea);
+		res.add(origin);
+		return res;
 	}
 }

--- a/src/test/java/com/esri/core/geometry/TestCentroid.java
+++ b/src/test/java/com/esri/core/geometry/TestCentroid.java
@@ -44,7 +44,7 @@ public class TestCentroid
     public void testEnvelope()
     {
         assertCentroid(new Envelope(1, 2, 3,4), new Point2D(2, 3));
-        assertCentroid(new Envelope(), null);
+        assertCentroidEmpty(new Envelope());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class TestCentroid
         multiPoint.add(0, 1);
 
         assertCentroid(multiPoint, new Point2D(1, 1));
-        assertCentroid(new MultiPoint(), null);
+        assertCentroidEmpty(new MultiPoint());
     }
 
     @Test
@@ -67,14 +67,14 @@ public class TestCentroid
         polyline.startPath(0, 0);
         polyline.lineTo(1, 2);
         polyline.lineTo(3, 4);
-        assertCentroid(polyline, new Point2D(1.5, 2));
+        assertCentroid(polyline, new Point2D(1.3377223398316207, 2.1169631197754946));
 
         polyline.startPath(1, -1);
         polyline.lineTo(2, 0);
         polyline.lineTo(10, 1);
-        assertCentroid(polyline, new Point2D(4.093485180902371 , 0.7032574095488145));
+        assertCentroid(polyline, new Point2D(3.93851092460519, 0.9659173294165462));
 
-        assertCentroid(new Polyline(), null);
+        assertCentroidEmpty(new Polyline());
     }
 
     @Test
@@ -102,14 +102,23 @@ public class TestCentroid
         polygon.lineTo(-1, -1);
         assertCentroid(polygon, new Point2D(2.166465459423206 , 1.3285043594902748));
 
-        assertCentroid(new Polygon(), null);
+        assertCentroidEmpty(new Polygon());
     }
 
-    private static void assertCentroid(Geometry geometry, Point2D expectedCentroid)
-    {
-        OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance().getOperator(Operator.Type.Centroid2D);
+	private static void assertCentroid(Geometry geometry, Point2D expectedCentroid) {
+		OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance()
+				.getOperator(Operator.Type.Centroid2D);
 
-        Point2D actualCentroid = operator.execute(geometry, null);
-        Assert.assertEquals(expectedCentroid, actualCentroid);
-    }
+		Point2D actualCentroid = operator.execute(geometry, null);
+		Assert.assertEquals(actualCentroid.x, expectedCentroid.x, 1e-13);
+		Assert.assertEquals(actualCentroid.y, expectedCentroid.y, 1e-13);
+	}
+	
+	private static void assertCentroidEmpty(Geometry geometry) {
+		OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance()
+				.getOperator(Operator.Type.Centroid2D);
+
+		Point2D actualCentroid = operator.execute(geometry, null);
+		Assert.assertTrue(actualCentroid == null);
+	}
 }

--- a/src/test/java/com/esri/core/geometry/TestCentroid.java
+++ b/src/test/java/com/esri/core/geometry/TestCentroid.java
@@ -26,99 +26,144 @@ package com.esri.core.geometry;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestCentroid
-{
-    @Test
-    public void testPoint()
-    {
-        assertCentroid(new Point(1, 2), new Point2D(1, 2));
-    }
+public class TestCentroid {
+	@Test
+	public void testPoint() {
+		assertCentroid(new Point(1, 2), new Point2D(1, 2));
+	}
 
-    @Test
-    public void testLine()
-    {
-        assertCentroid(new Line(0, 0, 10, 20), new Point2D(5, 10));
-    }
+	@Test
+	public void testLine() {
+		assertCentroid(new Line(0, 0, 10, 20), new Point2D(5, 10));
+	}
 
-    @Test
-    public void testEnvelope()
-    {
-        assertCentroid(new Envelope(1, 2, 3,4), new Point2D(2, 3));
-        assertCentroidEmpty(new Envelope());
-    }
+	@Test
+	public void testEnvelope() {
+		assertCentroid(new Envelope(1, 2, 3, 4), new Point2D(2, 3));
+		assertCentroidEmpty(new Envelope());
+	}
 
-    @Test
-    public void testMultiPoint()
-    {
-        MultiPoint multiPoint = new MultiPoint();
-        multiPoint.add(0, 0);
-        multiPoint.add(1, 2);
-        multiPoint.add(3, 1);
-        multiPoint.add(0, 1);
+	@Test
+	public void testMultiPoint() {
+		MultiPoint multiPoint = new MultiPoint();
+		multiPoint.add(0, 0);
+		multiPoint.add(1, 2);
+		multiPoint.add(3, 1);
+		multiPoint.add(0, 1);
 
-        assertCentroid(multiPoint, new Point2D(1, 1));
-        assertCentroidEmpty(new MultiPoint());
-    }
+		assertCentroid(multiPoint, new Point2D(1, 1));
+		assertCentroidEmpty(new MultiPoint());
+	}
 
-    @Test
-    public void testPolyline()
-    {
-        Polyline polyline = new Polyline();
-        polyline.startPath(0, 0);
-        polyline.lineTo(1, 2);
-        polyline.lineTo(3, 4);
-        assertCentroid(polyline, new Point2D(1.3377223398316207, 2.1169631197754946));
+	@Test
+	public void testPolyline() {
+		Polyline polyline = new Polyline();
+		polyline.startPath(0, 0);
+		polyline.lineTo(1, 2);
+		polyline.lineTo(3, 4);
+		assertCentroid(polyline, new Point2D(1.3377223398316207, 2.1169631197754946));
 
-        polyline.startPath(1, -1);
-        polyline.lineTo(2, 0);
-        polyline.lineTo(10, 1);
-        assertCentroid(polyline, new Point2D(3.93851092460519, 0.9659173294165462));
+		polyline.startPath(1, -1);
+		polyline.lineTo(2, 0);
+		polyline.lineTo(10, 1);
+		assertCentroid(polyline, new Point2D(3.93851092460519, 0.9659173294165462));
 
-        assertCentroidEmpty(new Polyline());
-    }
+		assertCentroidEmpty(new Polyline());
+	}
 
-    @Test
-    public void testPolygon()
-    {
-        Polygon polygon = new Polygon();
-        polygon.startPath(0, 0);
-        polygon.lineTo(1, 2);
-        polygon.lineTo(3, 4);
-        polygon.lineTo(5, 2);
-        polygon.lineTo(0, 0);
-        assertCentroid(polygon, new Point2D(2.5, 2));
+	@Test
+	public void testPolygon() {
+		Polygon polygon = new Polygon();
+		polygon.startPath(0, 0);
+		polygon.lineTo(1, 2);
+		polygon.lineTo(3, 4);
+		polygon.lineTo(5, 2);
+		polygon.lineTo(0, 0);
+		assertCentroid(polygon, new Point2D(2.5, 2));
 
-        // add a hole
-        polygon.startPath(2, 2);
-        polygon.lineTo(2.3, 2);
-        polygon.lineTo(2.3, 2.4);
-        polygon.lineTo(2, 2);
-        assertCentroid(polygon, new Point2D(2.5022670025188916 , 1.9989924433249369));
+		// add a hole
+		polygon.startPath(2, 2);
+		polygon.lineTo(2.3, 2);
+		polygon.lineTo(2.3, 2.4);
+		polygon.lineTo(2, 2);
+		assertCentroid(polygon, new Point2D(2.5022670025188916, 1.9989924433249369));
 
-        // add another polygon
-        polygon.startPath(-1, -1);
-        polygon.lineTo(3, -1);
-        polygon.lineTo(0.5, -2);
-        polygon.lineTo(-1, -1);
-        assertCentroid(polygon, new Point2D(2.166465459423206 , 1.3285043594902748));
+		// add another polygon
+		polygon.startPath(-1, -1);
+		polygon.lineTo(3, -1);
+		polygon.lineTo(0.5, -2);
+		polygon.lineTo(-1, -1);
+		assertCentroid(polygon, new Point2D(2.166465459423206, 1.3285043594902748));
 
-        assertCentroidEmpty(new Polygon());
-    }
+		assertCentroidEmpty(new Polygon());
+	}
+
+	@Test
+	public void testSmallPolygon() {
+		// https://github.com/Esri/geometry-api-java/issues/225
+
+		Polygon polygon = new Polygon();
+		polygon.startPath(153.492818, -28.13729);
+		polygon.lineTo(153.492821, -28.137291);
+		polygon.lineTo(153.492816, -28.137289);
+		polygon.lineTo(153.492818, -28.13729);
+
+		assertCentroid(polygon, new Point2D(153.492818333333333, -28.13729));
+	}
+
+	@Test
+	public void testZeroAreaPolygon() {
+		Polygon polygon = new Polygon();
+		polygon.startPath(153, 28);
+		polygon.lineTo(163, 28);
+		polygon.lineTo(153, 28);
+
+		Polyline polyline = (Polyline) polygon.getBoundary();
+		Point2D expectedCentroid = new Point2D(158, 28);
+
+		assertCentroid(polyline, expectedCentroid);
+		assertCentroid(polygon, expectedCentroid);
+	}
+
+	@Test
+	public void testDegeneratesToPointPolygon() {
+		Polygon polygon = new Polygon();
+		polygon.startPath(-8406364, 560828);
+		polygon.lineTo(-8406364, 560828);
+		polygon.lineTo(-8406364, 560828);
+		polygon.lineTo(-8406364, 560828);
+
+		assertCentroid(polygon, new Point2D(-8406364, 560828));
+	}
+
+	@Test
+	public void testZeroLengthPolyline() {
+		Polyline polyline = new Polyline();
+		polyline.startPath(153, 28);
+		polyline.lineTo(153, 28);
+
+		assertCentroid(polyline, new Point2D(153, 28));
+	}
+
+	@Test
+	public void testDegeneratesToPointPolyline() {
+		Polyline polyline = new Polyline();
+		polyline.startPath(-8406364, 560828);
+		polyline.lineTo(-8406364, 560828);
+
+		assertCentroid(polyline, new Point2D(-8406364, 560828));
+	}
 
 	private static void assertCentroid(Geometry geometry, Point2D expectedCentroid) {
-		OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance()
-				.getOperator(Operator.Type.Centroid2D);
 
-		Point2D actualCentroid = operator.execute(geometry, null);
-		Assert.assertEquals(actualCentroid.x, expectedCentroid.x, 1e-13);
-		Assert.assertEquals(actualCentroid.y, expectedCentroid.y, 1e-13);
+		Point2D actualCentroid = OperatorCentroid2D.local().execute(geometry, null);
+		Assert.assertEquals(expectedCentroid.x, actualCentroid.x, 1e-13);
+		Assert.assertEquals(expectedCentroid.y, actualCentroid.y, 1e-13);
 	}
-	
-	private static void assertCentroidEmpty(Geometry geometry) {
-		OperatorCentroid2D operator = (OperatorCentroid2D) OperatorFactoryLocal.getInstance()
-				.getOperator(Operator.Type.Centroid2D);
 
-		Point2D actualCentroid = operator.execute(geometry, null);
+	private static void assertCentroidEmpty(Geometry geometry) {
+
+		Point2D actualCentroid = OperatorCentroid2D.local().execute(geometry, null);
 		Assert.assertTrue(actualCentroid == null);
 	}
 }

--- a/src/test/java/com/esri/core/geometry/TestOGCCentroid.java
+++ b/src/test/java/com/esri/core/geometry/TestOGCCentroid.java
@@ -81,10 +81,13 @@ public class TestOGCCentroid {
 		//polygon is only vertices - compute as multipoint. Note that the closing vertex of the ring is not counted
 		assertCentroid("MULTIPOLYGON (((0 0, 0 0, 0 0), (1 1, 1 1, 1 1, 1 1)))", new Point(0.6, 0.6));
 		
-		// a test case from https://github.com/Esri/geometry-api-java/issues/225
+		// test cases from https://github.com/Esri/geometry-api-java/issues/225
 		assertCentroid(
 				"MULTIPOLYGON (((153.492818 -28.13729, 153.492821 -28.137291, 153.492816 -28.137289, 153.492818 -28.13729)))",
 				new Point(153.49281833333333, -28.13729));
+		assertCentroid(
+				"MULTIPOLYGON (((153.112475 -28.360526, 153.1124759 -28.360527, 153.1124759 -28.360526, 153.112475 -28.360526)))",
+				new Point(153.1124756, -28.360526333333333));
 		assertEmptyCentroid("MULTIPOLYGON EMPTY");
 	}
 

--- a/src/test/java/com/esri/core/geometry/TestOGCCentroid.java
+++ b/src/test/java/com/esri/core/geometry/TestOGCCentroid.java
@@ -38,7 +38,9 @@ public class TestOGCCentroid {
 	@Test
 	public void testLineString() {
 		assertCentroid("LINESTRING (1 1, 2 2, 3 3)", new Point(2, 2));
+		//closed path
 		assertCentroid("LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)", new Point(0.5, 0.5));
+		//all points coincide
 		assertCentroid("LINESTRING (0 0, 0 0, 0 0, 0 0, 0 0)", new Point(0.0, 0.0));
 		assertEmptyCentroid("LINESTRING EMPTY");
 	}
@@ -61,6 +63,7 @@ public class TestOGCCentroid {
 	@Test
 	public void testMultiLineString() {
 		assertCentroid("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))')))", new Point(3, 2));
+		assertCentroid("MULTILINESTRING ((1 1, 5 1), (2 4, 3 3, 4 4))')))", new Point(3, 2.0355339059327378));
 		assertCentroid("MULTILINESTRING ((0 0, 0 0, 0 0), (1 1, 1 1, 1 1, 1 1))", new Point(0.571428571428571429, 0.571428571428571429));
 		assertEmptyCentroid("MULTILINESTRING EMPTY");
 	}
@@ -88,7 +91,8 @@ public class TestOGCCentroid {
 	private static void assertCentroid(String wkt, Point expectedCentroid) {
 		OGCGeometry geometry = OGCGeometry.fromText(wkt);
 		OGCGeometry centroid = geometry.centroid();
-		Assert.assertEquals(centroid, new OGCPoint(expectedCentroid, geometry.getEsriSpatialReference()));
+		Assert.assertEquals(((OGCPoint)centroid).X(), expectedCentroid.getX(), 1e-13);
+		Assert.assertEquals(((OGCPoint)centroid).Y(), expectedCentroid.getY(), 1e-13);
 	}
 
 	private static void assertEmptyCentroid(String wkt) {


### PR DESCRIPTION
Issue: https://github.com/Esri/geometry-api-java/issues/225

Fix polyline centroid (original would only take endpoints of polyline paths)
Zero area polygon delegates to the polyline centroid and zero length polyline delegates to the multipoint centroid.
Rewrite polygon centroid for better accuracy.

@jagill I've copied your test cases
@mbasmanova 
@alocke 
