### PR TITLE
Refactor Point, add hashCode, a few fixes.

### DIFF
--- a/src/main/java/com/esri/core/geometry/AttributeStreamOfDbl.java
+++ b/src/main/java/com/esri/core/geometry/AttributeStreamOfDbl.java
@@ -352,7 +352,7 @@ final class AttributeStreamOfDbl extends AttributeStreamBase {
 			end = size;
 
 		for (int i = start; i < end; i++)
-			if (read(i) != _other.read(i))
+			if (!NumberUtils.isEqualNonIEEE(read(i), _other.read(i)))
 				return false;
 
 		return true;

--- a/src/main/java/com/esri/core/geometry/Envelope1D.java
+++ b/src/main/java/com/esri/core/geometry/Envelope1D.java
@@ -225,7 +225,13 @@ public final class Envelope1D implements Serializable {
 	
 	@Override
 	public int hashCode() {
-		return NumberUtils.hash(NumberUtils.hash(vmin), vmax);
+		if (isEmpty()) {
+			return NumberUtils.hash(NumberUtils.TheNaN);
+		}
+		
+		int hash = NumberUtils.hash(vmin);
+		hash = NumberUtils.hash(hash, vmax);
+		return hash;
 	}
 	
 }

--- a/src/main/java/com/esri/core/geometry/Envelope2D.java
+++ b/src/main/java/com/esri/core/geometry/Envelope2D.java
@@ -699,23 +699,14 @@ public final class Envelope2D implements Serializable {
 
 	@Override
 	public int hashCode() {
-
-		long bits = Double.doubleToLongBits(xmin);
-		int hc = (int) (bits ^ (bits >>> 32));
-
-		int hash = NumberUtils.hash(hc);
-
-		bits = Double.doubleToLongBits(xmax);
-		hc = (int) (bits ^ (bits >>> 32));
-		hash = NumberUtils.hash(hash, hc);
-
-		bits = Double.doubleToLongBits(ymin);
-		hc = (int) (bits ^ (bits >>> 32));
-		hash = NumberUtils.hash(hash, hc);
-
-		bits = Double.doubleToLongBits(ymax);
-		hc = (int) (bits ^ (bits >>> 32));
-		hash = NumberUtils.hash(hash, hc);
+		if (isEmpty()) {
+			return NumberUtils.hash(NumberUtils.TheNaN);
+		}
+		
+		int hash = NumberUtils.hash(xmin);
+		hash = NumberUtils.hash(hash, xmax);
+		hash = NumberUtils.hash(hash, ymin);
+		hash = NumberUtils.hash(hash, ymax);
 
 		return hash;
 	}

--- a/src/main/java/com/esri/core/geometry/Envelope3D.java
+++ b/src/main/java/com/esri/core/geometry/Envelope3D.java
@@ -320,6 +320,22 @@ public final class Envelope3D implements Serializable{
 		return true;
 	}
 
+	
+	@Override
+	public int hashCode() {
+		if (isEmpty()) {
+			return NumberUtils.hash(NumberUtils.TheNaN);
+		}
+		
+		int hash = NumberUtils.hash(xmin);
+		hash = NumberUtils.hash(hash, xmax);
+		hash = NumberUtils.hash(hash, ymin);
+		hash = NumberUtils.hash(hash, ymax);
+		hash = NumberUtils.hash(hash, zmin);
+		hash = NumberUtils.hash(hash, zmax);
+		return hash;
+	}
+
 	public void construct(Envelope1D xinterval, Envelope1D yinterval,
 			Envelope1D zinterval) {
 		if (xinterval.isEmpty() || yinterval.isEmpty()) {

--- a/src/main/java/com/esri/core/geometry/Line.java
+++ b/src/main/java/com/esri/core/geometry/Line.java
@@ -548,6 +548,11 @@ public final class Line extends Segment implements Serializable {
 		return _equalsImpl((Segment)other);
 	}
 	
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+
 	boolean equals(Line other) {
 		if (other == this)
 			return true;

--- a/src/main/java/com/esri/core/geometry/MultiVertexGeometryImpl.java
+++ b/src/main/java/com/esri/core/geometry/MultiVertexGeometryImpl.java
@@ -193,8 +193,6 @@ abstract class MultiVertexGeometryImpl extends MultiVertexGeometry {
 
 		Point outPoint = dst;
 		outPoint.assignVertexDescription(m_description);
-		if (outPoint.isEmpty())
-			outPoint._setToDefault();
 
 		for (int attributeIndex = 0; attributeIndex < m_description
 				.getAttributeCount(); attributeIndex++) {
@@ -958,9 +956,6 @@ abstract class MultiVertexGeometryImpl extends MultiVertexGeometry {
 		_verifyAllStreams();
 
 		outPoint.assignVertexDescription(m_description);
-		if (outPoint.isEmpty())
-			outPoint._setToDefault();
-
 		for (int attributeIndex = 0; attributeIndex < m_description
 				.getAttributeCount(); attributeIndex++) {
 			int semantics = m_description._getSemanticsImpl(attributeIndex);
@@ -991,8 +986,6 @@ abstract class MultiVertexGeometryImpl extends MultiVertexGeometry {
 
 		Point outPoint = new Point();
 		outPoint.assignVertexDescription(m_description);
-		if (outPoint.isEmpty())
-			outPoint._setToDefault();
 
 		for (int attributeIndex = 0; attributeIndex < m_description
 				.getAttributeCount(); attributeIndex++) {

--- a/src/main/java/com/esri/core/geometry/NumberUtils.java
+++ b/src/main/java/com/esri/core/geometry/NumberUtils.java
@@ -136,5 +136,18 @@ public class NumberUtils {
 		return (1103515245 * prevRand + 12345) & intMax(); // according to Wiki,
 															// this is gcc's
 	}
+	
+	/**
+	 * Returns true if two values are equal (also can compare inf and nan).
+	 */
+	static boolean isEqualNonIEEE(double a, double b) {
+		return a == b || (Double.isNaN(a) && Double.isNaN(b));
+	}
 
+	/**
+	 * Returns true if two values are equal (also can compare inf and nan).
+	 */
+	static boolean isEqualNonIEEE(double a, double b, double tolerance) {
+		return a == b || Math.abs(a - b) <= tolerance || (Double.isNaN(a) && Double.isNaN(b));
+	}
 }

--- a/src/main/java/com/esri/core/geometry/Point2D.java
+++ b/src/main/java/com/esri/core/geometry/Point2D.java
@@ -94,6 +94,12 @@ public final class Point2D implements Serializable{
 		
 		return x == v.x && y == v.y;
 	}
+
+	@Override
+	public int hashCode() {
+		return NumberUtils.hash(NumberUtils.hash(x), y);
+	}
+
 	
 	public void sub(Point2D other) {
 		x -= other.x;
@@ -751,11 +757,6 @@ public final class Point2D implements Serializable{
 		}
 	}
 	
-	@Override
-	public int hashCode() {
-		return NumberUtils.hash(NumberUtils.hash(x), y);
-	}
-
 	double getAxis(int ordinate) {
 		assert(ordinate == 0 || ordinate == 1);
 		return (ordinate == 0 ? x : y);

--- a/src/main/java/com/esri/core/geometry/Point3D.java
+++ b/src/main/java/com/esri/core/geometry/Point3D.java
@@ -132,4 +132,31 @@ public final class Point3D implements Serializable {
 		return NumberUtils.isNaN(x) || NumberUtils.isNaN(y) || NumberUtils.isNaN(z);
 	}
 
+	public boolean equals(Point3D other) {
+		//note that for nan value this returns false.
+		//this is by design for this class.
+		return x == other.x && y == other.y && z == other.z;
+	}
+	
+	@Override
+	public boolean equals(Object other_) {
+		if (other_ == this)
+			return true;
+
+		if (!(other_ instanceof Point3D))
+			return false;
+		
+		Point3D other = (Point3D)other_;
+		//note that for nan value this returns false.
+		//this is by design for this class.
+		return x == other.x && y == other.y && z == other.z;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = NumberUtils.hash(x);
+		hash = NumberUtils.hash(hash, y);
+		hash = NumberUtils.hash(hash, z);
+		return hash;
+	}
 }

--- a/src/main/java/com/esri/core/geometry/Segment.java
+++ b/src/main/java/com/esri/core/geometry/Segment.java
@@ -528,9 +528,6 @@ public abstract class Segment extends Geometry implements Serializable {
 
 		outPoint.assignVertexDescription(m_description);
 
-		if (outPoint.isEmptyImpl())
-			outPoint._setToDefault();
-
 		for (int attributeIndex = 0; attributeIndex < m_description
 				.getAttributeCount(); attributeIndex++) {
 			int semantics = m_description._getSemanticsImpl(attributeIndex);
@@ -689,12 +686,26 @@ public abstract class Segment extends Geometry implements Serializable {
 				|| m_yStart != other.m_yStart || m_yEnd != other.m_yEnd)
 			return false;
 		for (int i = 0; i < (m_description.getTotalComponentCount() - 2) * 2; i++)
-			if (m_attributes[i] != other.m_attributes[i])
+			if (!NumberUtils.isEqualNonIEEE(m_attributes[i], other.m_attributes[i]))
 				return false;
 
 		return true;
 	}
 
+	@Override
+	public int hashCode() {
+		int hash = m_description.hashCode();
+		hash = NumberUtils.hash(hash, m_xStart);
+		hash = NumberUtils.hash(hash, m_yStart);
+		hash = NumberUtils.hash(hash, m_xEnd);
+		hash = NumberUtils.hash(hash, m_yEnd);
+		for (int i = 0; i < (m_description.getTotalComponentCount() - 2) * 2; i++) {
+			hash = NumberUtils.hash(hash, m_attributes[i]);
+		}
+
+		return hash;
+	}
+	
 	/**
 	 * Returns true, when this segment is a closed curve (start point is equal
 	 * to end point exactly).

--- a/src/main/java/com/esri/core/geometry/SizeOf.java
+++ b/src/main/java/com/esri/core/geometry/SizeOf.java
@@ -68,7 +68,7 @@ public final class SizeOf {
 
 	public static final int SIZE_OF_MULTI_POINT_IMPL = 56;
 
-	public static final int SIZE_OF_POINT = 24;
+	public static final int SIZE_OF_POINT = 40;
 
 	public static final int SIZE_OF_POLYGON = 24;
 

--- a/src/test/java/com/esri/core/geometry/TestEnvelope.java
+++ b/src/test/java/com/esri/core/geometry/TestEnvelope.java
@@ -21,29 +21,58 @@ import static org.junit.Assert.assertTrue;
 
 public class TestEnvelope
 {
-    @Test
-    public void testIntersect()
-    {
-        assertIntersection(new Envelope(0, 0, 5, 5), new Envelope(0, 0, 5, 5), new Envelope(0, 0, 5, 5));
-        assertIntersection(new Envelope(0, 0, 5, 5), new Envelope(1, 1, 6, 6), new Envelope(1, 1, 5, 5));
-        assertIntersection(new Envelope(1, 2, 3, 4), new Envelope(0, 0, 2, 3), new Envelope(1, 2, 2, 3));
+	@Test
+	public void testIntersect() {
+		assertIntersection(new Envelope(0, 0, 5, 5), new Envelope(0, 0, 5, 5), new Envelope(0, 0, 5, 5));
+		assertIntersection(new Envelope(0, 0, 5, 5), new Envelope(1, 1, 6, 6), new Envelope(1, 1, 5, 5));
+		assertIntersection(new Envelope(1, 2, 3, 4), new Envelope(0, 0, 2, 3), new Envelope(1, 2, 2, 3));
 
-        assertNoIntersection(new Envelope(), new Envelope());
-        assertNoIntersection(new Envelope(0, 0, 5, 5), new Envelope());
-        assertNoIntersection(new Envelope(), new Envelope(0, 0, 5, 5));
-    }
+		assertNoIntersection(new Envelope(), new Envelope());
+		assertNoIntersection(new Envelope(0, 0, 5, 5), new Envelope());
+		assertNoIntersection(new Envelope(), new Envelope(0, 0, 5, 5));
+	}
 
-    private static void assertIntersection(Envelope envelope, Envelope other, Envelope intersection)
-    {
-        boolean intersects = envelope.intersect(other);
-        assertTrue(intersects);
-        assertEquals(envelope, intersection);
-    }
+	@Test
+	public void testEquals() {
+		Envelope env1 = new Envelope(10, 9, 11, 12);
+		Envelope env2 = new Envelope(10, 9, 11, 13);
+		Envelope1D emptyInterval = new Envelope1D();
+		emptyInterval.setEmpty();
+		assertFalse(env1.equals(env2));
+		env1.queryInterval(VertexDescription.Semantics.M, 0).equals(emptyInterval);
+		env2.setCoords(10, 9, 11, 12);
+		assertTrue(env1.equals(env2));
+		env1.addAttribute(VertexDescription.Semantics.M);
+		env1.queryInterval(VertexDescription.Semantics.M, 0).equals(emptyInterval);
+		assertFalse(env1.equals(env2));
+		env2.addAttribute(VertexDescription.Semantics.M);
+		assertTrue(env1.equals(env2));
+		Envelope1D nonEmptyInterval = new Envelope1D();
+		nonEmptyInterval.setCoords(1, 2);
+		env1.setInterval(VertexDescription.Semantics.M, 0, emptyInterval);
+		assertTrue(env1.equals(env2));
+		env2.setInterval(VertexDescription.Semantics.M, 0, emptyInterval);
+		assertTrue(env1.equals(env2));
+		env2.setInterval(VertexDescription.Semantics.M, 0, nonEmptyInterval);
+		assertFalse(env1.equals(env2));
+		env1.setInterval(VertexDescription.Semantics.M, 0, nonEmptyInterval);
+		assertTrue(env1.equals(env2));
+		env1.queryInterval(VertexDescription.Semantics.M, 0).equals(nonEmptyInterval);
+		env1.queryInterval(VertexDescription.Semantics.POSITION, 0).equals(new Envelope1D(10, 11));
+		env1.queryInterval(VertexDescription.Semantics.POSITION, 0).equals(new Envelope1D(9, 13));
+	}
+	
+	private static void assertIntersection(Envelope envelope, Envelope other, Envelope intersection) {
+		boolean intersects = envelope.intersect(other);
+		assertTrue(intersects);
+		assertEquals(envelope, intersection);
+	}
 
-    private static void assertNoIntersection(Envelope envelope, Envelope other)
-    {
-        boolean intersects = envelope.intersect(other);
-        assertFalse(intersects);
-        assertTrue(envelope.isEmpty());
-    }
+	private static void assertNoIntersection(Envelope envelope, Envelope other) {
+		boolean intersects = envelope.intersect(other);
+		assertFalse(intersects);
+		assertTrue(envelope.isEmpty());
+	}
+	
 }
+

--- a/src/test/java/com/esri/core/geometry/TestPoint.java
+++ b/src/test/java/com/esri/core/geometry/TestPoint.java
@@ -45,9 +45,35 @@ public class TestPoint extends TestCase {
 	public void testPt() {
 		Point pt = new Point();
 		assertTrue(pt.isEmpty());
+		assertTrue(Double.isNaN(pt.getX()));
+		assertTrue(Double.isNaN(pt.getY()));
+		assertTrue(Double.isNaN(pt.getM()));
+		assertTrue(pt.getZ() == 0);
+		Point pt1 = new Point();
+		assertTrue(pt.equals(pt1));
+		int hash1 = pt.hashCode();
 		pt.setXY(10, 2);
 		assertFalse(pt.isEmpty());
-		
+		assertTrue(pt.getX() == 10);
+		assertTrue(pt.getY() == 2);
+		assertTrue(pt.getXY().equals(new Point2D(10, 2)));
+		assertTrue(pt.getXYZ().x == 10);
+		assertTrue(pt.getXYZ().y == 2);
+		assertTrue(pt.getXYZ().z == 0);
+		assertFalse(pt.equals(pt1));
+		pt.copyTo(pt1);
+		assertTrue(pt.equals(pt1));
+		int hash2 = pt.hashCode();
+		assertFalse(hash1 == hash2);
+		pt.setZ(5);
+		assertFalse(pt.equals(pt1));
+		pt.copyTo(pt1);
+		assertTrue(pt.equals(pt1));
+		assertFalse(hash1 == pt.hashCode());
+		assertFalse(hash2 == pt.hashCode());
+		assertTrue(pt.hasZ());
+		assertTrue(pt.getZ() == 5);
+		assertTrue(pt.hasAttribute(VertexDescription.Semantics.Z));
 		pt.toString();
 	}
 


### PR DESCRIPTION
For issue https://github.com/Esri/geometry-api-java/issues/236

I wanted to change internals of the Point class, and this was a good chance.
Some fixes to ensure the objects that are equal have same hashCode value (miscompare happens for  NaN values in the attributes).