### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+cache:
+  directories:
+  - $HOME/.m2
 jdk:
     - openjdk9
     - openjdk10


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.