### PR TITLE
Declare "com.esri.geometry.api" as Java Module Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.esri.geometry</groupId>
 	<artifactId>esri-geometry-api</artifactId>
-	<version>2.2.4</version>
+	<version>2.2.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Esri Geometry API for Java</name>
@@ -179,6 +179,7 @@
 						<configuration>
 							<bnd>
 						<![CDATA[
+					  Automatic-Module-Name: com.esri.geometry.api
 					  Bundle-Copyright: Copyright (c) (${now;YYYY}) Esri
 					  Bundle-Description: ${project.description}
 					  Bundle-SymbolicName: ${project.groupId}.${project.artifactId}


### PR DESCRIPTION
This commit adds an `Automatic-Module-Name` attribute to the `META-INF/MANIFEST.MF` file for making possible to use ESRI geometry API in a Java Platform Module System (JPMS, a.k.a. "Jigsaw") without compiler warnings complaining that `esri-geometry-api.jar` has no module name.

This pull request takes `com.esri.geometry.api` as a module name for consistency with the OSGi module name introduced in previous commit, which was `com.esri.geometry.esri-geometry-api` (the `esri-geometry-` prefix is omitted because redundant and illegal as a JPMS module name). ESRI needs to decide if they are okay with that module name.

This pull request also sets the version number to `2.2.5-SNAPSHOT` on the assumption that more changes may be added before a 2.2.5 release.

# How to verify
Before this change, the following command line:

```
jar --describe-module -f esri-geometry-api-2.2.4.jar
```

produces the following (`esri.geometry.api` was derived by Java from the JAR filename):

```
esri.geometry.api@2.2.4 automatic
requires java.base mandated
contains com.esri.core.geometry
contains com.esri.core.geometry.ogc
```

After this change, the output become same as above but with `esri.geometry.api@2.2.4` replaced by `com.esri.geometry.api@2.2.5-SNAPSHOT`.

# Alternative
The `geometry-api-java` project currently sets the source and target Java versions to 1.7, which is not supported anymore by recent Java compilers. Attempt to compile this project with Java 20 produces the following error:

```
error: Source option 7 is no longer supported. Use 8 or later.
```

Since an upgrade is needed anyway, if ESRI is okay for skipping Java 8 and go directly to Java 9 or later, we should ignore this pull request and provide a real `module-info.java` file instead. Please let me know if this is ESRI's decision, in which case I can update this pull request accordingly.
